### PR TITLE
Add Ruby support

### DIFF
--- a/queries/ruby/rainbow-delimiters.scm
+++ b/queries/ruby/rainbow-delimiters.scm
@@ -1,0 +1,15 @@
+(block
+  "{" @opening
+  "}" @closing) @container
+
+(hash
+  "{" @opening
+  "}" @closing) @container
+
+(array
+  "[" @opening
+  "]" @closing) @container
+
+(parenthesized_statements
+  "(" @opening
+  ")" @closing) @container

--- a/test/highlight/ruby/regular.rb
+++ b/test/highlight/ruby/regular.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+an_array = [[['Hello', 'world!']]] # rubocop:disable Lint/UselessAssignment
+a_hash = { 'x' => { 'x' => { 'x' => 'Hello, world!' } } } # rubocop:disable Lint/UselessAssignment
+
+def greeting(name, age)
+  age_in_seconds = (((((age * 365))) * 24) * 60) * 60
+
+  puts "Hello, #{name}! You are #{age} years old, which is #{age_in_seconds} in seconds!"
+end
+
+puts greeting('Fry', 25)


### PR DESCRIPTION
Ruby doesn't use brackets for logic blocks, so there's not a lot we can do here. But I did what I can. I mostly matched what VS-Code does for Ruby files. The only difference I'm aware of is I also included `do_block` which I think is not TOO bad, and could be useful for deeply nested specs like the example provided.