### PR TITLE
C# - Implicit array creation

### DIFF
--- a/queries/c_sharp/rainbow-delimiters.scm
+++ b/queries/c_sharp/rainbow-delimiters.scm
@@ -138,6 +138,10 @@
   "[" @opening
   "]" @closing) @container
 
+(implicit_array_creation_expression
+  "[" @opening
+  "]" @closing) @container
+
 (implicit_stack_alloc_array_creation_expression
   "[" @opening
   "]" @closing) @container

--- a/test/highlight/c_sharp/array.cs
+++ b/test/highlight/c_sharp/array.cs
@@ -11,6 +11,7 @@ class Program {
     	};
     	int[] indices = new int[] {0};
     	int i = array3D[0, 0, 0];
+        var implicitArray = new[] { "" };
     	int j = indices[indices[indices[indices[0]]]];
     }
 }


### PR DESCRIPTION
Hi there!

Added a missing delimiter highlighting for C#.

Before:
![image](https://github.com/HiPhish/rainbow-delimiters.nvim/assets/125079891/b6f9fac1-ffa4-493d-9f6c-38dcafb87909)

After:
![image](https://github.com/HiPhish/rainbow-delimiters.nvim/assets/125079891/2fe583b6-7d59-41ac-aa35-fbc9791ebb27)
