### PR TITLE
feat(vue): highlight only tag names

### DIFF
--- a/queries/vue/rainbow-delimiters.scm
+++ b/queries/vue/rainbow-delimiters.scm
@@ -2,17 +2,20 @@
 ;;; languages
 
 (element
-  (start_tag) @opening
-  (end_tag)   @closing) @container
+  (start_tag (tag_name) @opening)
+  (end_tag (tag_name)   @closing)) @container
+
+(element
+  (self_closing_tag (tag_name) @opening)) @container
 
 (template_element
-  (start_tag) @opening
-  (end_tag)   @closing) @container
+  (start_tag (tag_name) @opening)
+  (end_tag (tag_name)   @closing)) @container
 
 (script_element
-  (start_tag) @opening
-  (end_tag)   @closing) @container
+  (start_tag (tag_name) @opening)
+  (end_tag (tag_name)   @closing)) @container
 
 (style_element
-  (start_tag) @opening
-  (end_tag)   @closing) @container
+  (start_tag (tag_name) @opening)
+  (end_tag (tag_name)   @closing)) @container


### PR DESCRIPTION
borrowed queries from html

before:

![image](https://github.com/HiPhish/rainbow-delimiters.nvim/assets/1159520/a3f9167f-f38a-4035-bdc8-75c3dee923be)

after:

![image](https://github.com/HiPhish/rainbow-delimiters.nvim/assets/1159520/6e9e758e-a1d1-4bdd-acd6-7dcdbecad080)

