### PR TITLE
fix(php): remove buggy string interpolation curly braces

### DIFF
--- a/queries/php/rainbow-delimiters.scm
+++ b/queries/php/rainbow-delimiters.scm
@@ -18,10 +18,6 @@
     "{" @opening
     "}" @closing) @container
 
-(encapsed_string
-    "{" @opening
-    "}" @closing) @container
-
 (array_creation_expression
     "[" @opening
     "]" @closing) @container


### PR DESCRIPTION
![image](https://github.com/HiPhish/rainbow-delimiters.nvim/assets/1159520/1b5b44e9-b718-4073-b61f-a4b2be011bad)

this snippet gives 6! combinations of opening and closing curly braces (because they all on same level in the tree). therefore it messes up highlight.

i think it would be better to remove this query. especially since there won't be encapsulation inside another encapsulation (i don't think it's even possible)