### PR TITLE
fix: for_each_child deprecation warning

### DIFF
--- a/lua/rainbow-delimiters/lib.lua
+++ b/lua/rainbow-delimiters/lib.lua
@@ -210,9 +210,11 @@ function M.detach(bufnr)
 	local parser = M.buffers[bufnr].parser
 
 	-- Clear all the namespaces for each language
-	parser:for_each_child(function(_, lang)
+
+	M.clear_namespace(bufnr, parser:lang())
+	for lang, _ in pairs(parser:children()) do
 		M.clear_namespace(bufnr, lang)
-	end, true)
+	end
 	-- Finally release all resources the parser is holding on to
 	parser:destroy()
 

--- a/lua/rainbow-delimiters/strategy/global.lua
+++ b/lua/rainbow-delimiters/strategy/global.lua
@@ -115,7 +115,7 @@ end
 ---Sets up all the callbacks and performs an initial highlighting
 local function setup_parser(bufnr, parser)
 	log.debug('Setting up parser for buffer %d', bufnr)
-	parser:for_each_child(function(p, lang)
+	local callback = function(p, lang)
 		log.debug("Setting up parser for '%s' in buffer %d", lang, bufnr)
 		-- Skip languages which are not supported, otherwise we get a
 		-- nil-reference error
@@ -151,7 +151,11 @@ local function setup_parser(bufnr, parser)
 			end,
 		}
 		log.trace("Done with setting up parser for '%s' in buffer %d", lang, bufnr)
-	end, true)
+	end
+	callback(parser, parser:lang())
+	for l, p in pairs(parser:children()) do
+		callback(p, l)
+	end
 
 	full_update(bufnr, parser)
 end

--- a/lua/rainbow-delimiters/strategy/local.lua
+++ b/lua/rainbow-delimiters/strategy/local.lua
@@ -168,7 +168,7 @@ end
 ---Sets up all the callbacks and performs an initial highlighting
 local function setup_parser(bufnr, parser)
 	log.debug('Setting up parser for buffer %d', bufnr)
-	parser:for_each_child(function(p, lang)
+	local callback = function(p, lang)
 		log.debug("Setting up parser for '%s' in buffer %d", lang, bufnr)
 		-- Skip languages which are not supported, otherwise we get a
 		-- nil-reference error
@@ -197,7 +197,11 @@ local function setup_parser(bufnr, parser)
 			end,
 		}
 		log.trace("Done with setting up parser for '%s' in buffer %d", lang, bufnr)
-	end, true)
+	end
+	callback(parser, parser:lang())
+	for l, p in pairs(parser:children()) do
+		callback(p, l)
+	end
 end
 
 function M.on_attach(bufnr, settings)
@@ -209,9 +213,9 @@ function M.on_attach(bufnr, settings)
 		buffer = bufnr,
 		callback = function(args)
 			lib.clear_namespace(bufnr, parser:lang())
-			parser:for_each_child(function(_, lang)
-				lib.clear_namespace(bufnr, lang)
-			end)
+			for l, _ in pairs(parser:children()) do
+				lib.clear_namespace(bufnr, l)
+			end
 			local_rainbow(args.buf, parser)
 		end
 	})


### PR DESCRIPTION
Closes #36 

As stated by HiPhish in the issue, the fix already exists but it's not committed to the repo.
I put this fix together for myself and other interested users while HiPhish is busy.
So feel free to close.