### PR TITLE
Rainbow blocks fix for Lua (+ other languages with a little work)

### DIFF
--- a/doc/rainbow-delimiters.txt
+++ b/doc/rainbow-delimiters.txt
@@ -13,7 +13,7 @@
                            | |_| |  __/ | | | | | | | | ||  __/ |  \__ \~
                            |____/ \___|_|_|_| |_| |_|_|\__\___|_|  |___/~
 
-                                                                 
+
 
 Author: Alejandro "HiPhish" Sanchez
 License: Apache-2.0
@@ -110,7 +110,7 @@ Here is an example configuration:
             \ 'RainbowDelimiterGreen',
             \ 'RainbowDelimiterViolet',
             \ 'RainbowDelimiterCyan',
-        \ ], 
+        \ ],
         \ 'blacklist': ['c', 'cpp'],
     \ }
 <
@@ -496,22 +496,22 @@ The queries need to define the following capture groups:
 
 - `@container`
   The entire delimited node.
-- `@opening`
-  The opening delimiter.
-- `@closing`
-  The closing delimiter.
-- `@intermediate`
-  Delimiters inside the block, such as a comma in an argument list or the
-  `elseif` of an `if`-`elseif`-`else` block in Lua.
+- `@delimiter`
+  Any delimiter you want to highlight in the current `@container`.
+- `@sentinel`
+  A marker used to signal that you are done with the `@container`.  This
+  should almost always be put right after the last `@delimiter` in the given
+  `@container`.
+- `@_<capture_name>`
+  Delimiters starting with `_` (underscore) are ignored for highlighting
+  purposes, but you can use them for treesitter predicates like
+  `#eq?`, `#any-eq?`, etc. (These are very rarely needed.)
 
-Only `@container` is mandatory, `@opening` and `@closing` will pretty much
-always be present as well.  The `@intermediate` capture group will be rarely
-used.  If we have too many `@intermediate` delimiters the code can become too
-vibrant and distracting.
+`@container` and `@sentinel` are mandatory, and `@delimiter` will always be
+present as well since `@delimiter` is what is highlighted.  The captures
+starting with underscore will be rarely used, since you only need them for
+predicates in a few special cases.
 
-WARNING: As of Neovim version 0.9.1 there is still a bug in the Tree-sitter
-integration.  If a capture matches multiple nodes (e.g. multiple `elseif`
-intermediate statements in an `if` block) only the last one will be used.
 
 Let's look at an example first.  Here is a snippet of HTML code:
 >
@@ -555,13 +555,13 @@ the entire link, not one of its delimiters.
 
 As you can see, it is up to interpretation as to what exactly constitutes a
 delimiter.  In this example for the sake of exhaustiveness we will consider
-the `<br/>` tag a delimiters.  The corresponding query is as follows:
+the `<br/>` tag a delimiter.  The corresponding query is as follows:
 >
     (element
-      (start_tag) @opening
+      (start_tag) @delimiter
       (element
-        (self_closing_tag) @intermediate)?  ;Optional!
-      (end_tag) @closing) @container
+        (self_closing_tag) @delimiter)?  ; Optional!
+      (end_tag) @delimiter @sentinel) @container
 <
 Highlighting the entire tag might be too vibrant though.  What if we want to
 highlight only the opening and closing angle brackets?  The query gets
@@ -570,19 +570,16 @@ tree.
 >
     (element
       ((start_tag
-          ["<" ">"] @opening)
+          ["<" ">"] @delimiter)
        (element
           (self_closing_tag
-            ["<" "/>"] @intermediate))?  ;Optional!
+            ["<" "/>"] @delimiter))?  ;Optional!
        (end_tag
-          ["</" ">"] @closing))) @container
+          "</" @delimiter
+          ">" @delimiter @sentinel))) @container
 <
-Both the opening and closing brackets are marked as one of either `@opening`,
-`@intermediate` or `@closing`.  This is because we care about delimiters at a
-semantic level: both ends of the brackets are considered opening if they are
-part of the opening tag.  This is just my opinion though, in your own query
-you might decide to capture all opening angle brackets as `@opening` and all
-closing angle brackets as `@closing`.
+Note that we don't want to put the `@sentinel` on the second to last `@delimiter`
+`"</"`, we need to be careful to put it on the last `@delimiter`.
 
 You might now see why we need the `@container` capture group: there is no way
 to know in general how deeply the delimiter is nested.  Even for one language
@@ -590,6 +587,49 @@ our understanding of what constitutes a delimiter is up for debate.  Therefore
 a human must decide for each query which node is the container and which nodes
 are the delimiters.  Capturing this information makes it available for use in
 strategies.
+
+We are not limited to only one opening and one closing delimiter.  The
+included default query captures the angle brackets and the tag name, but not
+attributes between the tag name and closing angle bracket.  This strikes a
+pleasant middle ground between the two above extremes.
+>
+    (element
+      (start_tag
+        "<" @delimiter
+        (tag_name) @delimiter
+        ">" @delimiter)
+      (end_tag
+        "</" @delimiter
+        (tag_name) @delimiter
+        ">" @delimiter @sentinel)) @container
+<
+Here both opening and closing tag have three delimiters each.
+
+In HTML the terminating slash in a self-closing tag is optional.  Instead of
+`<br/>` we can write `<br>`.  A naïve query would look like this:
+>
+    (element
+      (start_tag
+        "<" @delimiter
+        (tag_name) @delimiter @_tag_name
+        ">" @delimiter @sentinel)) @container
+<
+However, this query also matches the opening tag of regular tags like `<div>`.
+This is where the `@_tag_name` capture comes in.  The set of self-closing tags
+is finite, so we can list them explicitly.  This way a regular opening tag
+will not match this particular pattern.
+>
+    (element
+      (start_tag
+        "<" @delimiter
+        (tag_name) @delimiter @_tag_name
+        ">" @delimiter @sentinel)
+      ;; List abridged for brevity
+      (#any-of? @_tag_name "br" "hr" "input")) @container
+<
+We need the `@_tag_name` capture so that it can be used with the `#any-of?`
+predicate (|treesitter-predicate-any-of?|), but the capture itself is not used
+for highlighting.
 
 
 ------------------------------------------------------------------------------

--- a/lua/rainbow-delimiters/lib.lua
+++ b/lua/rainbow-delimiters/lib.lua
@@ -64,7 +64,7 @@ M.buffers = {}
 ---Fetches the query object for the given language from the settings.
 ---
 ---@param lang string  Name of the language to get the query for
----@return userdata query  The query object
+---@return Query? query  The query object
 function M.get_query(lang)
 	local name = config['query'][lang]
 	local query = get_query(lang, name)
@@ -211,7 +211,7 @@ function M.detach(bufnr)
 	local parser = M.buffers[bufnr].parser
 
 	-- Clear all the namespaces for each language
-	util.for_each_child(parser:lang(), parser, function(_, lang)
+	util.for_each_child(nil, parser:lang(), parser, function(_, lang)
 		M.clear_namespace(bufnr, lang)
 	end)
 	-- Finally release all resources the parser is holding on to

--- a/lua/rainbow-delimiters/util.lua
+++ b/lua/rainbow-delimiters/util.lua
@@ -25,11 +25,16 @@ local M = {}
 ---
 ---See also https://github.com/neovim/neovim/pull/25154 for a better
 ---replacement.
-function M.for_each_child(lang, language_tree, thunk)
-	thunk(language_tree, lang)
+---@param parent_lang string? # Parent language or nil
+---@param lang string
+---@param language_tree LanguageTree
+---@param thunk fun(p: LanguageTree, lang: string, parent_lang: string?): nil
+---@return nil
+function M.for_each_child(parent_lang, lang, language_tree, thunk)
+	thunk(language_tree, lang, parent_lang)
 	local children = language_tree:children()
 	for child_lang, child in pairs(children) do
-		M.for_each_child(child_lang, child, thunk)
+		M.for_each_child(lang, child_lang, child, thunk)
 	end
 end
 

--- a/queries/astro/rainbow-delimiters.scm
+++ b/queries/astro/rainbow-delimiters.scm
@@ -1,9 +1,13 @@
 (element
   (start_tag
-    (tag_name) @opening)
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
   (end_tag
-    (tag_name) @closing)) @container
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter @sentinel)) @container
 
 (interpolation
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/bash/rainbow-delimiters.scm
+++ b/queries/bash/rainbow-delimiters.scm
@@ -1,17 +1,17 @@
 (command_substitution
-  "$(" @opening
-  ")"  @closing) @container
+  "$(" @delimiter
+  ")"  @delimiter @sentinel) @container
 
 (expansion
-  "${" @opening
-  (":-" @intermediate)?
-  "}" @closing) @container
+  "${" @delimiter
+  (":-" @delimiter)?
+  "}" @delimiter @sentinel) @container
 
 ;;; The double-bracket variant is a bashism
 (test_command
-  ["[[" "["] @opening
-  ["]]" "]"] @closing) @container
+  ["[[" "["] @delimiter
+  ["]]" "]"] @delimiter @sentinel) @container
 
 (subshell
- "(" @opening
- ")" @closing) @container
+ "(" @delimiter
+ ")" @delimiter @sentinel) @container

--- a/queries/c/rainbow-delimiters.scm
+++ b/queries/c/rainbow-delimiters.scm
@@ -1,30 +1,48 @@
 (parameter_list
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (argument_list
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (compound_statement
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (initializer_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
+; This highlights the nested levels in an array differently
+; although they are the same level in terms of the nesting
+; of delimiters
 (subscript_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (field_declaration_list
-   "{" @opening
-   "}" @closing) @container
+   "{" @delimiter
+   "}" @delimiter @sentinel) @container
 
-;;; We could also add type casts, but those are not nested, so I don't think
-;;; they belong here.
+(array_declarator
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(sizeof_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(for_statement
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+; Comment out the following to not highlight type casts
+(cast_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+

--- a/queries/c_sharp/rainbow-delimiters.scm
+++ b/queries/c_sharp/rainbow-delimiters.scm
@@ -1,147 +1,147 @@
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (argument_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parameter_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (if_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (for_each_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (for_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (while_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (do_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (tuple_type
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (tuple_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (attribute_argument_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (attribute_list
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (switch_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (switch_body
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (switch_expression
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (default_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (catch_declaration
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (catch_filter_clause
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (using_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (lock_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (cast_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (type_of_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (size_of_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (checked_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (declaration_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (accessor_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (interpolation
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (anonymous_object_creation_expression
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (enum_member_declaration_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (type_parameter_list
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
 
 (type_argument_list
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
 
 (initializer_expression
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (array_rank_specifier
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (bracketed_argument_list
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (implicit_array_creation_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (implicit_stack_alloc_array_creation_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/clojure/rainbow-delimiters.scm
+++ b/queries/clojure/rainbow-delimiters.scm
@@ -1,19 +1,19 @@
 (list_lit
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (vec_lit
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (map_lit
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (set_lit
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (anon_fn_lit
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/queries/commonlisp/rainbow-delimiters.scm
+++ b/queries/commonlisp/rainbow-delimiters.scm
@@ -1,9 +1,9 @@
 (list_lit
-  "(" @opening
+  "(" @delimiter
    _*
-   ")" @closing) @container
+   ")" @delimiter @sentinel) @container
 
 (defun
-  "(" @opening
+  "(" @delimiter
    _*
-   ")" @closing) @container
+   ")" @delimiter @sentinel) @container

--- a/queries/cpp/rainbow-delimiters.scm
+++ b/queries/cpp/rainbow-delimiters.scm
@@ -1,45 +1,45 @@
 ;;; NOTE: The C and C++ grammar have diverged, so I cannot include the C query.
 
 (parameter_list
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (argument_list
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (compound_statement
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (initializer_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (subscript_argument_list
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (field_declaration_list
-   "{" @opening
-   "}" @closing) @container
+   "{" @delimiter
+   "}" @delimiter @sentinel) @container
 
 (declaration_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (template_parameter_list
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
 
 (initializer_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (template_argument_list
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container

--- a/queries/css/rainbow-delimiters.scm
+++ b/queries/css/rainbow-delimiters.scm
@@ -1,7 +1,7 @@
 (block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (parenthesized_query
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/queries/cuda/rainbow-delimiters.scm
+++ b/queries/cuda/rainbow-delimiters.scm
@@ -1,5 +1,5 @@
 ; inherits: cpp
 
 (kernel_call_syntax
-   "<<<" @opening
-   ">>>" @closing) @container
+   "<<<" @delimiter
+   ">>>" @delimiter @sentinel) @container

--- a/queries/dart/rainbow-delimiters.scm
+++ b/queries/dart/rainbow-delimiters.scm
@@ -1,31 +1,31 @@
 (block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (arguments
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (class_body
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (formal_parameter_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (optional_formal_parameters
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (list_literal
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (set_or_map_literal
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (type_arguments
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container

--- a/queries/elixir/rainbow-delimiters.scm
+++ b/queries/elixir/rainbow-delimiters.scm
@@ -1,31 +1,30 @@
 (call
   (arguments
-    "(" @opening
-    ")" @closing) @container)
+    "(" @delimiter
+    ")" @delimiter @sentinel) @container)
 
 (block
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
-;; This pattern breaks the parser.
-; Error attaching strategy to buffer 1: /usr/share/nvim/runtime/lua/vim/treesitter/query.lua:259: query: invalid structure at position 170 for language elixir
 (string
   (interpolation
-    "#{" @opening
-    "}" @closing) @container)
+    "#{" @delimiter
+    "}" @delimiter @sentinel) @container)
 
 (tuple
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (list
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (bitstring
-  "<<" @opening
-  ">>" @closing) @container
+  "<<" @delimiter
+  ">>" @delimiter @sentinel) @container
 
 (map
-  "{" @opening
-  "}" @closing) @container
+  "%" @delimiter
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/fennel/rainbow-delimiters.scm
+++ b/queries/fennel/rainbow-delimiters.scm
@@ -1,165 +1,124 @@
 (list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (table
-  "{" @opening
-  (":" @intermediate)*
-  "}" @closing) @container
+  "{" @delimiter
+  (":" @delimiter _)*
+  "}" @delimiter @sentinel) @container
 
 (sequential_table
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (fn
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (lambda
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (let
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (set
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 
-;;; BUG: regarding the next 6 pairs of queries:
-;;;      since both pairs of delimiters
-;;;      are direct children of the same `TSNode`
-;;;      they get highligthed in different colours
-
-;;; NOTE: https://github.com/neovim/neovim/pull/17099
+;;; NOTE: The following queries contain one set of outer parentheses and one
+;;;       set of inner parentheses, but both are on the same level of the tree.
+;;;       Thus we cannot match the inner ones one level deeper than the outer
+;;;       ones.
 
 (each
-  "(" @opening
-  ")" @closing) @container
-
-(each
-  "[" @opening
-  "]" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (collect
-  "(" @opening
-  ")" @closing) @container
-
-(collect
-  "[" @opening
-  "]" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (icollect
-  "(" @opening
-  ")" @closing) @container
-
-(icollect
-  "[" @opening
-  "]" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 ;;; TODO: add these when treesitter parser
 ;;;       adds support for fennel 1.1.1
 
 ;; (fcollect
-;;   "(" @opening
-;;   ")" @closing) @container
+;;   "(" @delimiter
+;;   ")" @delimiter @sentinel) @container
 ;;
 ;; (fcollect
-;;   "[" @opening
-;;   "]" @closing) @container
+;;   "[" @delimiter
+;;   "]" @delimiter @sentinel) @container
 
 (accumulate
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (accumulate
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 ;;; TODO: add these when treesitter parser
 ;;;       adds support for fennel 1.3.0
 
 ;; (faccumulate
-;;   "(" @opening
-;;   ")" @closing) @container
+;;   "(" @delimiter
+;;   ")" @delimiter @sentinel) @container
 ;;
 ;; (faccumulate
-;;   "[" @opening
-;;   "]" @closing) @container
-
-;;; TODO: (reo101) swap out the above queries
-;;;       for these (below) when 17099 (see NOTE) is merged
-
-;; (each
-;;    ["[" ")"]+ @opening
-;;    ["]" ")"]+ @closing) @container
-;;
-;; (collect
-;;    ["[" ")"]+ @opening
-;;    ["]" ")"]+ @closing) @container
-;;
-;; (icollect
-;;    ["[" ")"]+ @opening
-;;    ["]" ")"]+ @closing) @container
-;;
-;; (fcollect
-;;    ["[" ")"]+ @opening
-;;    ["]" ")"]+ @closing) @container
-;;
-;; (accumulate
-;;    ["[" ")"]+ @opening
-;;    ["]" ")"]+ @closing) @container
-;;
-;; (faccumulate
-;;    ["[" ")"]+ @opening
-;;    ["]" ")"]+ @closing) @container
+;;   "[" @delimiter
+;;   "]" @delimiter @sentinel) @container
 
 (for
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (for_clause
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (var
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parameters
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (let_clause
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (quoted_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (local
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (multi_value_binding
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (hashfn
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (match
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (sequential_table_pattern
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (sequential_table_binding
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/fish/rainbow-delimiters.scm
+++ b/queries/fish/rainbow-delimiters.scm
@@ -1,15 +1,15 @@
 (command_substitution
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (concatenation
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (list_element_access
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (brace_expansion
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/go/rainbow-delimiters.scm
+++ b/queries/go/rainbow-delimiters.scm
@@ -1,67 +1,67 @@
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (import_spec_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (var_declaration
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (const_declaration
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (field_declaration_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (argument_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parameter_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (expression_switch_statement
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (type_switch_statement
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (literal_value
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (slice_type
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (map_type
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (interface_type
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (type_parameter_list
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (type_arguments
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (index_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/haskell/rainbow-delimiters.scm
+++ b/queries/haskell/rainbow-delimiters.scm
@@ -1,71 +1,104 @@
 (exp_parens
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (exp_tuple
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (con_unit
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (exports
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (export_names
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (import_list
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (import_item
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (type_parens
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (type_tuple
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (pat_parens
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (pat_tuple
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(pat_list
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(exp_lambda
+  "\\" @delimiter
+  @sentinel) @container
 
 (type_tuple
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (deriving
-  (("(" @opening)
-   (")" @closing))) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (record_fields
-  (("{" @opening)
-   ("}" @closing))) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (exp_record
-  (("{" @opening)
-   ("}" @closing))) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (pat_fields
-  (("{" @opening)
-   ("}" @closing))) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (exp_list
-  (("[" @opening)
-   ("]" @closing))) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (type_list
-  (("[" @opening)
-   ("]" @closing))) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(exp_list_comprehension
+  "[" @delimiter
+  "|" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(exp_arithmetic_sequence
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(context
+  "(" @delimiter
+   ")" @delimiter @sentinel) @container
+
+(con_list
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(exp_section_right
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(exp_name
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/queries/hcl/rainbow-delimiters.scm
+++ b/queries/hcl/rainbow-delimiters.scm
@@ -1,15 +1,15 @@
 (tuple
-  (tuple_start "[") @opening
-  (tuple_end   "]") @closing) @container
+  (tuple_start "[") @delimiter
+  (tuple_end   "]") @delimiter @sentinel) @container
 
 (function_call
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (block
-  (block_start "{") @opening
-  (block_end   "}") @closing) @container
+  (block_start "{") @delimiter
+  (block_end   "}") @delimiter @sentinel) @container
 
 (object
-  (object_start "{") @opening
-  (object_end   "}") @closing) @container
+  (object_start "{") @delimiter
+  (object_end   "}") @delimiter @sentinel) @container

--- a/queries/html/rainbow-delimiters.scm
+++ b/queries/html/rainbow-delimiters.scm
@@ -1,19 +1,61 @@
-;;; A pair of opening and closing tag with any content in-between. Excludes
-;;; self-closing tags or opening tags without closing tag.
+;;; A pair of delimiter tags with any content in-between.
+;;; Last tag should be a sentinel.
 
 (element
-  (start_tag (tag_name) @opening)
-  ; (element (self_closing_tag) @intermediate)*
-  (end_tag (tag_name) @closing)) @container
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
+  (end_tag
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter @sentinel)) @container
 
 (element
-  (self_closing_tag (tag_name) @opening)) @container
+  (self_closing_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    "/>" @delimiter @sentinel)) @container
+
+(element
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter @_tag_name
+    ">" @delimiter @sentinel)
+  (#any-of? @_tag_name
+   "area"
+   "base"
+   "br"
+   "col"
+   "embed"
+   "hr"
+   "img"
+   "input"
+   "link"
+   "meta"
+   "param"
+   "source"
+   "track"
+   "wbr")
+) @container
 
 (style_element
-  (start_tag (tag_name) @opening)
-  ; (element (self_closing_tag) @intermediate)*
-  (end_tag (tag_name) @closing)) @container
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
+  (element (self_closing_tag) @delimiter)*
+  (end_tag
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter @sentinel)) @container
 
 (script_element
-  (start_tag (tag_name) @opening)
-  (end_tag (tag_name) @closing)) @container
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
+  (end_tag
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter @sentinel)) @container

--- a/queries/janet_simple/rainbow-delimiters.scm
+++ b/queries/janet_simple/rainbow-delimiters.scm
@@ -1,23 +1,23 @@
 (par_tup_lit
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (par_arr_lit
-  "@(" @opening
-  ")" @closing) @container
+  "@(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (sqr_tup_lit
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (sqr_arr_lit
-  "@[" @opening
-  "]" @closing) @container
+  "@[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (struct_lit
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (tbl_lit
-  "@{" @opening
-  "}" @closing) @container
+  "@{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/java/rainbow-delimiters.scm
+++ b/queries/java/rainbow-delimiters.scm
@@ -1,27 +1,27 @@
 (class_body
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (formal_parameters
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (argument_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (dimensions
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (array_access
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (type_arguments
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container

--- a/queries/javascript/rainbow-delimiters-react.scm
+++ b/queries/javascript/rainbow-delimiters-react.scm
@@ -2,71 +2,85 @@
 
 ;; String interpolation inside template strings
 (template_substitution
-  "${" @opening
-  "}"  @closing) @container
+  "${" @delimiter
+  "}"  @delimiter @sentinel) @container
 
 (object
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (statement_block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (class_body
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (arguments
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (formal_parameters
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (subscript_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (named_imports
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (export_clause
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (object_pattern
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (array
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 
 ;;; React.js support
 (jsx_element
   open_tag: (jsx_opening_element
-              name: (identifier) @opening)
+              "<" @delimiter
+              name: (identifier) @delimiter
+              ">" @delimiter)
   close_tag: (jsx_closing_element
-               name: (identifier) @closing)) @container
+               "</" @delimiter
+               name: (identifier) @delimiter
+               ">" @delimiter @sentinel)) @container
 
 (jsx_element
   open_tag: (jsx_opening_element
-              name: (member_expression) @opening)
+              "<" @delimiter
+              name: (member_expression) @delimiter
+              ">" @delimiter)
   close_tag: (jsx_closing_element
-               name: (member_expression) @closing)) @container
+              "</" @delimiter
+               name: (member_expression) @delimiter
+              ">" @delimiter @sentinel)) @container
 
 (jsx_self_closing_element
-  name: (identifier) @opening
-  "/>" @closing) @container
+  "<" @delimiter
+  name: (identifier) @delimiter
+  "/>" @delimiter @sentinel) @container
+
+(jsx_self_closing_element
+  "<" @delimiter
+  name: (member_expression) @delimiter
+  "/>" @delimiter @sentinel) @container
 
 (jsx_expression
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/javascript/rainbow-delimiters.scm
+++ b/queries/javascript/rainbow-delimiters.scm
@@ -3,49 +3,49 @@
 
 ;; String interpolation inside template strings
 (template_substitution
-  "${" @opening
-  "}"  @closing) @container
+  "${" @delimiter
+  "}"  @delimiter @sentinel) @container
 
 (object
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (statement_block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (class_body
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (arguments
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (formal_parameters
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (subscript_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (named_imports
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (export_clause
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (object_pattern
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (array
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/json/rainbow-delimiters.scm
+++ b/queries/json/rainbow-delimiters.scm
@@ -1,7 +1,7 @@
 (object
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (array
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/jsonnet/rainbow-delimiters.scm
+++ b/queries/jsonnet/rainbow-delimiters.scm
@@ -1,39 +1,39 @@
 (anonymous_function
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (functioncall
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (bind
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesis
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (field
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (fieldname
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (array
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (forloop
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (indexing
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (object
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/julia/rainbow-delimiters.scm
+++ b/queries/julia/rainbow-delimiters.scm
@@ -1,23 +1,23 @@
 (vector_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (matrix_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (parameter_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (argument_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (comprehension_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/latex/rainbow-blocks.scm
+++ b/queries/latex/rainbow-blocks.scm
@@ -1,11 +1,11 @@
 (inline_formula
-  "$" @opening
-  "$" @closing) @container
+  "$" @delimiter
+  "$" @delimiter @sentinel) @container
 
 (generic_environment
-  (begin) @opening
-  (end)   @closing) @container
+  (begin) @delimiter
+  (end)   @delimiter @sentinel) @container
 
 (math_environment
-  (begin) @opening
-  (end)   @closing) @container
+  (begin) @delimiter
+  (end)   @delimiter @sentinel) @container

--- a/queries/latex/rainbow-delimiters.scm
+++ b/queries/latex/rainbow-delimiters.scm
@@ -1,15 +1,15 @@
 (curly_group
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (curly_group_text
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (curly_group_text_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (inline_formula
-  "$" @opening
-  "$" @closing) @container
+  "$" @delimiter
+  "$" @delimiter @sentinel) @container

--- a/queries/lua/rainbow-blocks.scm
+++ b/queries/lua/rainbow-blocks.scm
@@ -4,59 +4,62 @@
 
 
 (function_declaration
-  "function" @opening
-  "end" @closing) @container
+  "function" @delimiter
+  "end" @delimiter @sentinel) @container
+
+(function_definition
+  "function" @delimiter
+  "end" @delimiter @sentinel) @container
 
 (if_statement
-  "if" @opening
-  ; "then" @opening
-  ; (elseif_statement
-  ;   "elseif" @intermediate
-  ;   "then" @intermediate)*
-  ; (else_statement
-  ;   "else" @intermediate)?
-  "end" @closing) @container
+  "if" @delimiter
+  "then" @delimiter
+  (elseif_statement
+    "elseif" @delimiter
+    "then" @delimiter)*
+  (else_statement
+    "else" @delimiter)?
+  "end" @delimiter @sentinel) @container
 
 (while_statement
-  "while" @opening
-  ; "do" @opening
-  "end" @closing) @container
+  "while" @delimiter
+  "do" @delimiter
+  "end" @delimiter @sentinel) @container
 
 (repeat_statement
-  "repeat" @opening
-  "until" @closing) @container
+  "repeat" @delimiter
+  "until" @delimiter @sentinel) @container
 
 (for_statement
-  "for" @opening
-  ; clause: [(for_generic_clause
-  ;            "in" @opening)
-  ;          (for_numeric_clause)]
-  ; "do" @opening
-  "end" @closing) @container
+  "for" @delimiter
+  (for_generic_clause
+    "in" @delimiter)?
+  "do" @delimiter
+  "end" @delimiter @sentinel) @container
 
 (do_statement
-  "do" @opening
-  "end" @closing) @container
+  "do" @delimiter
+  "end" @delimiter @sentinel) @container
 
 
 ;;; Copied over from rainbow-parens
 
 (arguments
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parameters
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (table_constructor
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (bracket_index_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/lua/rainbow-delimiters.scm
+++ b/queries/lua/rainbow-delimiters.scm
@@ -1,19 +1,19 @@
 (arguments
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parameters
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (table_constructor
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (bracket_index_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/nix/rainbow-delimiters.scm
+++ b/queries/nix/rainbow-delimiters.scm
@@ -1,19 +1,19 @@
 (attrset_expression
-  ("{" @opening)
-  ("}" @closing)) @container
+  ("{" @delimiter)
+  ("}" @delimiter @sentinel)) @container
 
 (formals
-  ("{" @opening)
-  ("}" @closing)) @container
+  ("{" @delimiter)
+  ("}" @delimiter @sentinel)) @container
 
 (list_expression
-  ("[" @opening)
-  ("]" @closing)) @container
+  ("[" @delimiter)
+  ("]" @delimiter @sentinel)) @container
 
 (parenthesized_expression
-  ("(" @opening)
-  (")" @closing)) @container
+  ("(" @delimiter)
+  (")" @delimiter @sentinel)) @container
 
 (interpolation
-  ("${" @opening)
-  ("}" @closing)) @container
+  ("${" @delimiter)
+  ("}" @delimiter @sentinel)) @container

--- a/queries/perl/rainbow-delimiters.scm
+++ b/queries/perl/rainbow-delimiters.scm
@@ -1,85 +1,86 @@
 (argument
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (array
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (array_dereference
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (array_ref
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (array_ref
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (hash_access_variable
-  "->{" @opening
-  "}" @closing) @container
+  "->{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (hash_access_variable
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (hash_ref
-  "{" @opening
-  "}" @closing) @container
+  "+" @delimiter
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (multi_var_declaration
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (standalone_block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (parenthesized_argument
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (list_block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (word_list_qw
-  (start_delimiter_qw) @opening
-  (end_delimiter_qw) @closing) @container
+  (start_delimiter_qw) @delimiter
+  (end_delimiter_qw) @delimiter @sentinel) @container
 
 (regex_pattern_qr
-  (start_delimiter) @opening
-  (end_delimiter) @closing) @container
+  (start_delimiter) @delimiter
+  (end_delimiter) @delimiter @sentinel) @container
 
 (command_qx_quoted
-  (start_delimiter) @opening
-  (end_delimiter) @closing) @container
+  (start_delimiter) @delimiter
+  (end_delimiter) @delimiter @sentinel) @container
 
 (string_qq_quoted
-  (start_delimiter) @opening
-  (end_delimiter) @closing) @container
+  (start_delimiter) @delimiter
+  (end_delimiter) @delimiter @sentinel) @container
 
 (patter_matcher_m
-  (start_delimiter) @opening
-  (end_delimiter) @closing) @container
+  (start_delimiter) @delimiter
+  (end_delimiter) @delimiter @sentinel) @container
 
 (substitution_pattern_s
-  (start_delimiter) @opening
-  (separator_delimiter) @intermediate
-  (end_delimiter) @closing) @container
+  (start_delimiter) @delimiter
+  (separator_delimiter) @delimiter
+  (end_delimiter) @delimiter @sentinel) @container
 
 (transliteration_tr_or_y
-  (start_delimiter) @opening
-  (separator_delimiter) @intermediate
-  (end_delimiter) @closing) @container
+  (start_delimiter) @delimiter
+  (separator_delimiter) @delimiter
+  (end_delimiter) @delimiter @sentinel) @container

--- a/queries/php/rainbow-delimiters.scm
+++ b/queries/php/rainbow-delimiters.scm
@@ -1,32 +1,31 @@
 (parenthesized_expression
-    "(" @opening
-    ")" @closing) @container
+    "(" @delimiter
+    ")" @delimiter @sentinel) @container
 
 (arguments
-    "(" @opening
-    ")" @closing) @container
+    "(" @delimiter
+    ")" @delimiter @sentinel) @container
 
 (formal_parameters
-    "(" @opening
-    ")" @closing) @container
+    "(" @delimiter
+    ")" @delimiter @sentinel) @container
 
 (declaration_list
-    "{" @opening
-    "}" @closing) @container
+    "{" @delimiter
+    "}" @delimiter @sentinel) @container
 
 (compound_statement
-    "{" @opening
-    "}" @closing) @container
+    "{" @delimiter
+    "}" @delimiter @sentinel) @container
 
-;; Commented out until https://github.com/neovim/neovim/pull/17099 is resolved
-; (encapsed_string
-;     "{" @opening
-;     "}" @closing) @container
+(encapsed_string
+    "{" @delimiter
+    "}" @delimiter @sentinel) @container
 
 (array_creation_expression
-    "[" @opening
-    "]" @closing) @container
+    "[" @delimiter
+    "]" @delimiter @sentinel) @container
 
 (subscript_expression
-    "[" @opening
-    "]" @closing) @container
+    "[" @delimiter
+    "]" @delimiter @sentinel) @container

--- a/queries/python/rainbow-delimiters.scm
+++ b/queries/python/rainbow-delimiters.scm
@@ -1,47 +1,51 @@
 (list
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (list_comprehension
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (dictionary
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (dictionary_comprehension
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (set
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (set_comprehension
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (tuple
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (generator_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parameters
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (argument_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (subscript
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(type_parameter
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/query/rainbow-delimiters.scm
+++ b/queries/query/rainbow-delimiters.scm
@@ -1,7 +1,15 @@
 (named_node
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(grouping
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (list
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(predicate
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/queries/r/rainbow-delimiters.scm
+++ b/queries/r/rainbow-delimiters.scm
@@ -1,19 +1,19 @@
 (call
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (subset
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (subset2
-  "[[" @opening
-  "]]" @closing) @container
+  "[[" @delimiter
+  "]]" @delimiter @sentinel) @container
 
 (if
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (brace_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/racket/rainbow-delimiters.scm
+++ b/queries/racket/rainbow-delimiters.scm
@@ -1,15 +1,14 @@
 (list
-  "(" @opening
-  (dot)? @intermediate
-  ")" @closing) @container
+  "(" @delimiter
+  (dot)? @delimiter
+  ")" @delimiter @sentinel) @container
 
 (list
-  "[" @opening
-  (dot)? @intermediate
-  "]" @closing) @container
+  "[" @delimiter
+  (dot)? @delimiter
+  "]" @delimiter @sentinel) @container
 
 (list
-  "{" @opening
-  (dot)? @intermediate
-  "}" @closing) @container
-
+  "{" @delimiter
+  (dot)? @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/regex/rainbow-delimiters.scm
+++ b/queries/regex/rainbow-delimiters.scm
@@ -1,17 +1,17 @@
 (anonymous_capturing_group
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 ;;; The inversion `^` should be an opening node as well
 (character_class
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (count_quantifier
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 ;;; We should probably include the character after `?` like `=` as well
 (lookaround_assertion
-  "(?" @opening
-  ")" @closing) @container
+  "(?" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/queries/ruby/rainbow-delimiters.scm
+++ b/queries/ruby/rainbow-delimiters.scm
@@ -1,15 +1,19 @@
 (block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (hash
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (array
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (parenthesized_statements
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(block_parameters
+  "|" @delimiter
+  "|" @delimiter @sentinel) @container

--- a/queries/rust/rainbow-delimiters.scm
+++ b/queries/rust/rainbow-delimiters.scm
@@ -1,119 +1,129 @@
 (parenthesized_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (declaration_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (field_declaration_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (ordered_field_declaration_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (enum_variant_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (use_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (field_initializer_list
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (parameters
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (arguments
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (match_block
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (tuple_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (tuple_type
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (token_tree
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (token_tree
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (token_tree
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (token_tree_pattern
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (token_repetition_pattern
-  "(" @opening
-  ")" @closing) @container
+  "$" @delimiter
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(token_repetition
+  "$" @delimiter
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (attribute_item
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (inner_attribute_item
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (type_arguments
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
 
 (type_parameters
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
 
 (closure_parameters
-  "|" @opening
-  "|" @closing) @container
+  "|" @delimiter
+  "|" @delimiter @sentinel) @container
 
 (array_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (index_expression
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (tuple_struct_pattern
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (tuple_pattern
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (struct_pattern
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (slice_pattern
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (macro_definition
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(visibility_modifier
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/queries/scheme/rainbow-delimiters.scm
+++ b/queries/scheme/rainbow-delimiters.scm
@@ -1,5 +1,7 @@
 (list
-  "(" @opening
-   ;; I don't know how match the dot as an optional node
-   ;; (symbol)? @intermediate (#eq? @intermediate ".")
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(list
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/sql/rainbow-delimiters.scm
+++ b/queries/sql/rainbow-delimiters.scm
@@ -1,24 +1,28 @@
 (subquery
-    "(" @opening
-    ")" @closing) @container
+    "(" @delimiter
+    ")" @delimiter @sentinel) @container
 
 (invocation
-    "(" @opening
-    ")" @closing) @container
+    "(" @delimiter
+    ")" @delimiter @sentinel) @container
 
 (list
-    "(" @opening
-    ")" @closing) @container
+    "(" @delimiter
+    ")" @delimiter @sentinel) @container
 
-;; A parenthesized expression; the delimiters are actually outside the
-;; expression, but that's OK because the nesting level only looks at containers
-(
-    "(" @opening
-    .
-    [
-        (binary_expression)
-        (literal)
-    ] @container
-    .
-    ")" @closing
-)
+(where
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(binary_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel
+  ) @container
+
+; The following can cause problems with (((())))
+(term
+  "(" @delimiter
+  ; ("(" ")")* ; to fix _some_ problems, this can be uncommented
+  ")" @delimiter @sentinel
+  ) @container
+

--- a/queries/tsx/rainbow-delimiters.scm
+++ b/queries/tsx/rainbow-delimiters.scm
@@ -2,20 +2,35 @@
 
 (jsx_element
   open_tag: (jsx_opening_element
-              name: (identifier) @opening)
+              "<" @delimiter
+              name: (identifier) @delimiter
+              ">" @delimiter)
   close_tag: (jsx_closing_element
-               name: (identifier) @closing)) @container
+               "</" @delimiter
+               name: (identifier) @delimiter
+               ">" @delimiter @sentinel)) @container
 
 (jsx_element
   open_tag: (jsx_opening_element
-              name: (member_expression) @opening)
+              "<" @delimiter
+              name: (member_expression) @delimiter
+              ">" @delimiter)
   close_tag: (jsx_closing_element
-               name: (member_expression) @closing)) @container
+              "</" @delimiter
+               name: (member_expression) @delimiter
+              ">" @delimiter @sentinel)) @container
 
 (jsx_self_closing_element
-  name: (identifier) @opening
-  "/>" @closing) @container
+  "<" @delimiter
+  name: (identifier) @delimiter
+  "/>" @delimiter @sentinel) @container
+
+
+(jsx_self_closing_element
+  "<" @delimiter
+  name: (member_expression) @delimiter
+  "/>" @delimiter @sentinel) @container
 
 (jsx_expression
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/typescript/rainbow-delimiters.scm
+++ b/queries/typescript/rainbow-delimiters.scm
@@ -1,17 +1,17 @@
 ; inherits: javascript
 
 (type_arguments
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
 
 (type_parameters
-  "<" @opening
-  ">" @closing) @container
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
 
 (lookup_type
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (object_type
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/queries/verilog/rainbow-blocks.scm
+++ b/queries/verilog/rainbow-blocks.scm
@@ -1,83 +1,83 @@
 ; match blocks
 
 (seq_block
-  "begin" @opening
-  "end"   @closing) @container
+  "begin" @delimiter
+  "end"   @delimiter @sentinel) @container
 
 ; match parentheses
 
 (packed_dimension
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (data_type
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (parameter_port_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (named_port_connection
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (list_of_port_declarations
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parameter_value_assignment
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (named_parameter_assignment
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (hierarchical_instance
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (cast
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (conditional_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (event_control
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (primary
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (constant_primary
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (concatenation
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (constant_concatenation
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (multiple_concatenation
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (constant_select1
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (bit_select1
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (select1
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/verilog/rainbow-delimiters.scm
+++ b/queries/verilog/rainbow-delimiters.scm
@@ -1,75 +1,75 @@
 (packed_dimension
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (data_type
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (parameter_port_list
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (named_port_connection
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (list_of_port_declarations
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parameter_value_assignment
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (named_parameter_assignment
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (hierarchical_instance
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (cast
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (conditional_statement
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (event_control
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (primary
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (constant_primary
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (concatenation
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (constant_concatenation
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (multiple_concatenation
-  "{" @opening
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (constant_select1
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (bit_select1
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (select1
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/vim/rainbow-delimiters.scm
+++ b/queries/vim/rainbow-delimiters.scm
@@ -3,27 +3,27 @@
 ;;; one. All the parentheses and the integer literal are on the same level.
 ;;; This makes it impossible to apply alternating highlights.
 (list
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
 
 (dictionnary  ;; this is no typo, "dictionary" is misspelled in the parser
-  "{" @opening
+  "{" @delimiter
   (dictionnary_entry
-    ":" @intermediate)
-  "}" @closing) @container
+    ":" @delimiter)
+  "}" @delimiter @sentinel) @container
 
 (call_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (unary_operation
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (binary_operation
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (ternary_expression
-  "(" @opening
-  ")" @closing) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/queries/vimdoc/rainbow-delimiters.scm
+++ b/queries/vimdoc/rainbow-delimiters.scm
@@ -1,0 +1,3 @@
+;;; Intentionally empty.  Vim help files can have other languages embedded and
+;;; we want to let those grammars handle the highlighting.  This query only
+;;; exists to satisfy the requirements of this plugin.

--- a/queries/vue/rainbow-delimiters.scm
+++ b/queries/vue/rainbow-delimiters.scm
@@ -2,20 +2,51 @@
 ;;; languages
 
 (element
-  (start_tag (tag_name) @opening)
-  (end_tag (tag_name)   @closing)) @container
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
+  (end_tag
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter @sentinel)) @container
 
 (element
-  (self_closing_tag (tag_name) @opening)) @container
+  (self_closing_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    "/>" @delimiter @sentinel)) @container
 
 (template_element
-  (start_tag (tag_name) @opening)
-  (end_tag (tag_name)   @closing)) @container
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
+  (end_tag
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter @sentinel)) @container
 
 (script_element
-  (start_tag (tag_name) @opening)
-  (end_tag (tag_name)   @closing)) @container
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
+  (end_tag
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter @sentinel)) @container
 
 (style_element
-  (start_tag (tag_name) @opening)
-  (end_tag (tag_name)   @closing)) @container
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
+  (end_tag
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter @sentinel)) @container
+
+(interpolation
+  "{{" @delimiter
+  "}}" @delimiter @sentinel) @container

--- a/queries/yaml/rainbow-delimiters.scm
+++ b/queries/yaml/rainbow-delimiters.scm
@@ -1,8 +1,7 @@
 (flow_mapping
-  "{" @opening
-  (flow_pair ":" @intermediate)*
-  "}" @closing) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (flow_sequence
-  "[" @opening
-  "]" @closing) @container
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/queries/zig/rainbow-delimiters.scm
+++ b/queries/zig/rainbow-delimiters.scm
@@ -1,125 +1,97 @@
 (ParamDeclList
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (FnCallArguments
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (IfPrefix
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (ForPrefix
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (WhilePrefix
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (LinkSection
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (CallConv
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (AsmExpr
-   "(" @opening
-   ")" @closing) @container
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (ContainerDeclType
-   "(" @opening
-   ")" @closing) @container
-
-;;; BUG: regarding the next 3 pairs of queries:
-;;;      since both pairs of delimiters
-;;;      are direct children of the same `TSNode`
-;;;      they get highligthed in different colours
-
-;;; NOTE: https://github.com/neovim/neovim/pull/17099
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (AsmInputItem
-   "[" @opening
-   "]" @closing) @container
-
-(AsmInputItem
-   "(" @opening
-   ")" @closing) @container
+   "[" @delimiter
+   "]" @delimiter
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (AsmOutputItem
-   "[" @opening
-   "]" @closing) @container
-
-(AsmOutputItem
-   "(" @opening
-   ")" @closing) @container
+   "[" @delimiter
+   "]" @delimiter
+   "(" @delimiter
+   ")" @delimiter @sentinel) @container
 
 (SwitchExpr
-   "(" @opening
-   ")" @closing) @container
-
-(SwitchExpr
-   "{" @opening
-   "}" @closing) @container
-
-;;; TODO: (reo101) swap out the above queries
-;;;       for these (below) when 17099 (see NOTE) is merged
-
-;; (AsmInputItem
-;;    ["[" ")"]+ @opening
-;;    ["]" ")"]+ @closing) @container
-;;
-;; (AsmOutputItem
-;;    ["[" ")"]+ @opening
-;;    ["]" ")"]+ @closing) @container
-;;
-;; (SwitchExpr
-;;    ["(" "{"]+ @opening
-;;    [")" "}"]+ @closing) @container
+   "(" @delimiter
+   ")" @delimiter
+   "{" @delimiter
+   "}" @delimiter @sentinel) @container
 
 (ArrayTypeStart
-   "[" @opening
-   "]" @closing) @container
+   "[" @delimiter
+   "]" @delimiter @sentinel) @container
 
 (SliceTypeStart
-   "[" @opening
-   "]" @closing) @container
+   "[" @delimiter
+   "]" @delimiter @sentinel) @container
 
 (PtrTypeStart
-   "[" @opening
-   "]" @closing) @container
+   "[" @delimiter
+   "]" @delimiter @sentinel) @container
 
 (SuffixOp
-   "[" @opening
-   "]" @closing) @container
+   "[" @delimiter
+   "]" @delimiter @sentinel) @container
 
 (Block
-   "{" @opening
-   "}" @closing) @container
+   "{" @delimiter
+   "}" @delimiter @sentinel) @container
 
 (ContainerDecl
-   "{" @opening
-   "}" @closing) @container
+   "{" @delimiter
+   "}" @delimiter @sentinel) @container
 
 (InitList
-   "{" @opening
-   "}" @closing) @container
+   "{" @delimiter
+   "}" @delimiter @sentinel) @container
 
 (FormatSequence
-   "{" @opening
-   "}" @closing) @container
+   "{" @delimiter
+   "}" @delimiter @sentinel) @container
 
 (Payload
-  "|" @opening
-  "|" @closing) @container
+  "|" @delimiter
+  "|" @delimiter @sentinel) @container
 
 (PtrListPayload
-  "|" @opening
-  "|" @closing) @container
+  "|" @delimiter
+  "|" @delimiter @sentinel) @container
 
 (PtrIndexPayload
-  "|" @opening
-  "|" @closing) @container
+  "|" @delimiter
+  "|" @delimiter @sentinel) @container

--- a/test/highlight/html/regular.html
+++ b/test/highlight/html/regular.html
@@ -19,8 +19,13 @@
 		<p>
 			This is an <a href="https://example.com">Example link</a>.
 		</p>
+		<hr />
 		<p>
-			This is an <a href="https://example.com">Example<br/>link</a> with<br/> line <br/>break.
+			This is an <a href="https://example.com">Example<br/>link</a> with<br> line <br/>break.
 		</p>
+		<hr>
+		<div>
+			<p>Good<span>bye</span>.</p>
+		</div>
 	</body>
 </html>

--- a/test/highlight/jsx/regular.jsx
+++ b/test/highlight/jsx/regular.jsx
@@ -37,6 +37,7 @@ function app() {
 			<ComponentWith.property>
 				{someFunction().map((x) => <div></div>)}
 			</ComponentWith.property>
+			<ComponentWith.property bool={true} arr={[1, 2, 3]} />
 			<button onClick={hello}>Click me!</button>
 		</div>
 	)

--- a/test/highlight/markdown/extra.md
+++ b/test/highlight/markdown/extra.md
@@ -1,0 +1,9 @@
+Some markdown.
+```markdown
+~~~lua
+print({{{{}}}})
+print({{{{}}}})
+vim.cmd[[echo str([])]]
+~~~
+```
+More markdown

--- a/test/highlight/markdown/regular.md
+++ b/test/highlight/markdown/regular.md
@@ -46,6 +46,8 @@ print(one[one[one[1]]])
 vim.cmd [[
    echo a(b(c(d(e(f())))))
 ]]
+-- Embedded Vim script on one line
+vim.cmd[[echo a(b(c(d())))]]
 ```
 
 ### Vim script

--- a/test/highlight/scheme/regular.scm
+++ b/test/highlight/scheme/regular.scm
@@ -5,6 +5,14 @@
     (add (add1 x)
          (sub1 y))))
 
+;; R6RS allows square brackets as well
+(define [mult x y]
+  "A silly way of multiplying to numbers recursively"
+  (if [= 1 y]
+    x
+    (add (add x x)
+         (sub1 y))))
+
 (define-syntax foo
   (syntax-rules ()
     ((_ a ...)

--- a/test/highlight/sql/regular.sql
+++ b/test/highlight/sql/regular.sql
@@ -1,6 +1,9 @@
+SELECT (1 + (2 + (3 + (4 + (5 + (6 + (7 + (8 + ((9) + (0))))))))));
+
 SELECT
-    (1 + ((2) - 3)) AS "expression",
-    ((((())))) AS "list",
+    (1 + ((2)((())) - 3)) AS "expression",
+    (()) AS "list",
+    -- ((((())))) AS "list" -- this will cause problems with the highlighting!
     "users"."id" AS "user_id",
     SUM("orders"."sum_prices") AS "user_orders_amount"
 FROM "users"
@@ -19,13 +22,13 @@ WHERE "users"."age" = (2 + (3 * 4)) AND (4 - (5 * 0)) = (1 * (2 + 2 + (5)))
 GROUP BY
     "users"."id";
 
-select *
-from products
+SELECT *
+FROM products
 where (
     Product_Category = 'Fit'
-	and  Product_number IN (1234, 1235, 1236, 1237, 1238)
+	AND  Product_number IN (1234, 1235, 1236, 1237, 1238)
 )
 or
-	(Product_Category in ('Tight', 'Wide') and Product_number = 1324);
+	(Product_Category IN ('Tight', 'Wide') AND Product_number = 1324);
 
 SELECT 10 FROM generate_series(1, 10) WHERE (TRUE);

--- a/test/highlight/tsx/regular.tsx
+++ b/test/highlight/tsx/regular.tsx
@@ -72,6 +72,7 @@ function app() {
 			<ComponentWith.property>
 				{someFunction().map((x) => <div></div>)}
 			</ComponentWith.property>
+			<ComponentWith.property bool={true} arr={[1, 2, 3]} />
 			<CustomComponent bool={true} arr={[1, 2, 3]} />
 		</div>
 	)

--- a/test/highlight/vue/regular.vue
+++ b/test/highlight/vue/regular.vue
@@ -1,12 +1,16 @@
 <!-- A plain default Vue.js program using the default languages -->
 
 <template>
-    {{ errCode }}
-    {{ $t(errMsg) }}
-    <a-button type="primary" @click="goToHome">goToHome</a-button>
-    <template #footer>
-        <a-button type="primary" @click="goToHome">{{ $t(errMsg) }}</a-button>
-    </template>
+	{{ errCode }}
+	{{ $t(errMsg) }}
+	<a-button type="primary" @click="goToHome">goToHome</a-button>
+	<template #footer>
+		<a-button type="primary" @click="goToHome">{{ $t(errMsg) }}</a-button>
+		<div>
+			<p>Hello<br/>world</p>
+			<hr/>
+		</div>
+	</template>
 </template>
 
 <script setup>

--- a/test/highlight/yaml/regular.yaml
+++ b/test/highlight/yaml/regular.yaml
@@ -22,4 +22,4 @@ json_compatibility:
 list_of_objects:
   - { key1: value, key2: value, key3: value }
   - { key1: value, key2: value, key3: value }  # A comment
-  - { key1: { key2: { key3: value } } }        # Nested map
+  - { key1: { key2: { key3: value, key4: value, key5: value } } } # Nested map

--- a/test/stress/markdown/lorem-ipsum.md
+++ b/test/stress/markdown/lorem-ipsum.md
@@ -7,6 +7,20 @@ print 'This is an injected language'
 print({{{{{{{}}}}}}})
 ```
 
+```markdown
+Injected markdown.
+~~~lua
+print 'Injected Lua'
+print({{{{}}}})
+vim.cmd[[echo str([])]]
+vim.cmd[[
+echo 'Injected vim in injected Lua'
+echo str([])
+]]
+~~~
+More injected markdown.
+```
+
 ## Cupit Phoce sonus
 
 Lorem markdownum acernas. **Ignis ore amplius** dixit, supremumque miserere
@@ -39,6 +53,14 @@ puts("This is an injected language")
         }
     }
 }
+```
+
+```c
+puts("This is a second c code block")
+```
+
+```c
+puts("This is a third c code block")
 ```
 
 > Delius irascere cuncti Argolis, femineis **ubi est** relatis Tityos supple


### PR DESCRIPTION
This is a draft of a fix to the problem where rainbow-delimiters doesn't catch the same group multiple times. E.g., it couldn't catch `elseif` and `else` in Lua before. 

I have time to edit and add improvements if you have any suggestions, or we could add it as another strategy if you don't want it to replace the old `global`? 

I have only tested it in Lua and Rust for now (and before getting rainbow blocks to work better than before in other languages we need to edit the corresponding .scm files). But it works exactly as I would expect so far. 

To use this it is important that each `@container` only has at most one `@closing`, but you can have as many `@opening` or `@intermediate` as you want. 

<img width="841" alt="Screenshot 2023-10-06 at 22 33 51" src="https://github.com/HiPhish/rainbow-delimiters.nvim/assets/7075380/e9077462-89b8-4b98-9404-9d6c25af2d4d">
