### PR TITLE
Use idiomatic setup function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,22 @@ The equivalent code in Lua:
    }
 
 Please refer to the `manual`_ for more details.  For those who prefer a `setup`
-function there is the module `rainbow-delimiters.setup`.
+function there is the module `rainbow-delimiters.setup` that accepts all the
+same parameters as `g:rainbow-delimiters`.
+
+.. code:: lua
+
+   require('rainbow-delimiters.setup').setup({
+       strategy = { 
+           -- ...
+       },
+       query = {
+           -- ...
+       },
+       highlight = {
+           -- ...
+       },
+   })
 
 
 Help wanted

--- a/lua/rainbow-delimiters/setup.lua
+++ b/lua/rainbow-delimiters/setup.lua
@@ -1,7 +1,11 @@
+local M = {}
+
 ---Apply the given configuration to the rainbow-delimiter settings.  Will
 ---overwrite existing settings.
 ---
---- @param config table  Settings, same format as `vim.g.rainbow_delimiters`
-return function(config)
-	vim.g.rainbow_delimiters = config
+--- @param opts table  Settings, same format as `vim.g.rainbow_delimiters`
+function M.setup(opts)
+	vim.g.rainbow_delimiters = opts
 end
+
+return M


### PR DESCRIPTION
This permits simple integration with common plugin managers. With [lazy.nvim](https://github.com/folke/lazy.nvim), for example, one could use the following:

```lua
{
    'HiPhish/rainbow-delimiters.nvim',
    main = 'rainbow-delimiters.setup',
    opts = {
        strategy = {
            [''] = rainbow_delimiters.strategy['global'],
            vim = rainbow_delimiters.strategy['local'],
        },
        query = {
            [''] = 'rainbow-delimiters',
            lua = 'rainbow-blocks',
        },
        highlight = {
            'RainbowDelimiterRed',
            'RainbowDelimiterYellow',
            'RainbowDelimiterBlue',
            'RainbowDelimiterOrange',
            'RainbowDelimiterGreen',
            'RainbowDelimiterViolet',
            'RainbowDelimiterCyan',
        },
    },
}
```

Closes #4.