### PR TITLE
Add more LuaLS types for better LSP info

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,3 +27,11 @@ following criteria:
 
 If there are many test cases or if the code becomes too verbose feel free to
 create multiple test files.
+
+In addition to the queries and test file(s), please consider adding the type
+annotations in `lua/rainbow-delimiters.types.lua` if you are adding queries
+for a new language. You will need to update:
+
+- `@class rainbow_delimiters.config.strategies`
+- `@class rainbow_delimiters.config.queries`
+- `@alias rainbow_delimiters.language`

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Configuration is done by setting entries in the Vim script dictionary
            \ 'RainbowDelimiterGreen',
            \ 'RainbowDelimiterViolet',
            \ 'RainbowDelimiterCyan',
-       \ ], 
+       \ ],
    \ }
 
 The equivalent code in Lua:
@@ -60,6 +60,7 @@ The equivalent code in Lua:
    -- This module contains a number of default definitions
    local rainbow_delimiters = require 'rainbow-delimiters'
 
+   ---@type rainbow_delimiters.config
    vim.g.rainbow_delimiters = {
        strategy = {
            [''] = rainbow_delimiters.strategy['global'],
@@ -87,7 +88,7 @@ same parameters as `g:rainbow-delimiters`.
 .. code:: lua
 
    require('rainbow-delimiters.setup').setup {
-       strategy = { 
+       strategy = {
            -- ...
        },
        query = {

--- a/doc/rainbow-delimiters.txt
+++ b/doc/rainbow-delimiters.txt
@@ -108,6 +108,7 @@ Alternatively, the same configuration in Lua:
     -- This module contains a number of default definitions
     local rainbow_delimiters = require 'rainbow-delimiters'
 
+    ---@type rainbow_delimiters.config
     vim.g.rainbow_delimiters = {
         strategy = {
             [''] = rainbow_delimiters.strategy['global'],
@@ -423,9 +424,9 @@ object-oriented terminology we would say that a strategy table must implement
 the strategy protocol.
 >
     strategy = {
-        on_attach = function(bufnr: number, settings: table),
-        on_detach = function(bufnr: string),
-        on_reset  = function(bufnr: number, settings: table),
+        on_attach = function(bufnr: integer, settings: table),
+        on_detach = function(bufnr: integer),
+        on_reset  = function(bufnr: integer, settings: table),
     }
 <
 

--- a/lua/rainbow-delimiters.lua
+++ b/lua/rainbow-delimiters.lua
@@ -18,7 +18,7 @@
 local lib = require 'rainbow-delimiters.lib'
 
 ---Disable rainbow delimiters for a given buffer.
----@param bufnr number  Buffer number, zero for current buffer.
+---@param bufnr integer  Buffer number, zero for current buffer.
 local function disable(bufnr)
 	if not bufnr or bufnr == 0 then bufnr = vim.api.nvim_get_current_buf() end
 	lib.detach(bufnr)
@@ -26,13 +26,15 @@ local function disable(bufnr)
 end
 
 ---Enable rainbow delimiters for a given buffer.
----@param bufnr number  Buffer number, zero for current buffer.
+---@param bufnr integer  Buffer number, zero for current buffer.
 local function enable(bufnr)
 	if not bufnr or bufnr == 0 then bufnr = vim.api.nvim_get_current_buf() end
 	lib.buffers[bufnr] = nil
 	lib.attach(bufnr)
 end
 
+---Toggle rainbow delimiters for a given buffer.
+---@param bufnr integer  Buffer number, zero for current buffer.
 local function toggle(bufnr)
 	if not bufnr or bufnr == 0 then bufnr = vim.api.nvim_get_current_buf() end
 	if lib.buffers[bufnr] then
@@ -47,8 +49,11 @@ local M = {
 	hlgroup_at = lib.hlgroup_at,
 	---Available default highlight strategies
 	strategy = {
+		---Global highlighting strategy
 		['global'] = require 'rainbow-delimiters.strategy.global',
+		---Local highlighting strategy
 		['local']  = require 'rainbow-delimiters.strategy.local',
+		---Empty highlighting strategy for testing
 		['noop']   = require 'rainbow-delimiters.strategy.no-op',
 	},
 	enable  = enable,

--- a/lua/rainbow-delimiters.types.lua
+++ b/lua/rainbow-delimiters.types.lua
@@ -1,0 +1,229 @@
+---@meta
+
+
+--# Utility Library #--
+
+---Strategy to use for highlighting with rainbow-delimiters
+---Must implement `on_attach`, `on_detach` and `on_reset`
+---@class rainbow_delimiters.strategy
+---`on_attach`: setup the highlighting on attach
+---@field on_attach fun(bufnr: integer, settings: rainbow_delimiters.buffer_settings)
+---`on_detach`: remove any unneccesary remaining setup on detach
+---@field on_detach fun(bufnr: integer)
+---`on_reset`: update the highlighting on reset
+---@field on_reset fun(bufnr: integer, settings: rainbow_delimiters.buffer_settings)
+
+---@class (exact) rainbow_delimiters.buffer_settings
+---@field strategy rainbow_delimiters.strategy
+---@field parser LanguageTree
+---@field lang string
+
+
+--# Config #--
+
+---Configuration table for rainbow-delimiters
+---@class (exact) rainbow_delimiters.config
+---Strategy to use for highlighting
+---@field strategy rainbow_delimiters.config.strategies?
+---Query to use for highlighting
+---@field query rainbow_delimiters.config.queries?
+---Highlight colors
+---@field highlight string[]?
+---Whitelist for languages to highlight
+---@field whitelist rainbow_delimiters.language[]?
+---Blacklist for languages not to highlight
+---@field blacklist rainbow_delimiters.language[]?
+---Logging with log file and log level
+---@field log rainbow_delimiters.logging?
+
+---@class rainbow_delimiters.config.strategies
+---@field [''] (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field astro (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field bash (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field c (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field c_sharp (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field clojure (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field commonlisp (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field cpp (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field css (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field cuda (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field cue (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field dart (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field elixir (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field elm (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field fennel (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field fish (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field go (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field haskell (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field hcl (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field html (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field janet_simple (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field java (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field javascript (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field json (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field json5 (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field jsonc (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field jsonnet (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field julia (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field kotlin (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field latex (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field lua (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field luadoc (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field make (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field markdown (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field nim (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field nix (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field perl (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field php (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field python (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field query (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field r (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field racket (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field regex (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field rst (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field ruby (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field rust (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field scheme (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field scss (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field sql (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field templ (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field toml (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field tsx (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field typescript (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field verilog (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field vim (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field vimdoc (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field vue (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field yaml (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---@field zig (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+---User defined language, not part of rainbow_delimiters support
+---@field [string] (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
+
+---@class rainbow_delimiters.config.queries
+---@field [''] ('rainbow-delimiters' | string)?
+---@field astro ('rainbow-delimiters' | string)?
+---@field bash ('rainbow-delimiters' | string)?
+---@field c ('rainbow-delimiters' | string)?
+---@field c_sharp ('rainbow-delimiters' | string)?
+---@field clojure ('rainbow-delimiters' | string)?
+---@field commonlisp ('rainbow-delimiters' | string)?
+---@field cpp ('rainbow-delimiters' | string)?
+---@field css ('rainbow-delimiters' | string)?
+---@field cuda ('rainbow-delimiters' | string)?
+---@field cue ('rainbow-delimiters' | string)?
+---@field dart ('rainbow-delimiters' | string)?
+---@field elixir ('rainbow-delimiters' | string)?
+---@field elm ('rainbow-delimiters' | string)?
+---@field fennel ('rainbow-delimiters' | string)?
+---@field fish ('rainbow-delimiters' | string)?
+---@field go ('rainbow-delimiters' | string)?
+---@field haskell ('rainbow-delimiters' | string)?
+---@field hcl ('rainbow-delimiters' | string)?
+---@field html ('rainbow-delimiters' | string)?
+---@field janet_simple ('rainbow-delimiters' | string)?
+---@field java ('rainbow-delimiters' | string)?
+---@field javascript ('rainbow-delimiters' | 'rainbow-parens' | 'rainbow-delimiters-react' | string)?
+---@field json ('rainbow-delimiters' | string)?
+---@field json5 ('rainbow-delimiters' | string)?
+---@field jsonc ('rainbow-delimiters' | string)?
+---@field jsonnet ('rainbow-delimiters' | string)?
+---@field julia ('rainbow-delimiters' | string)?
+---@field kotlin ('rainbow-delimiters' | string)?
+---@field latex ('rainbow-delimiters' | 'rainbow-blocks' | string)?
+---@field lua ('rainbow-delimiters' | 'rainbow-blocks' | string)?
+---@field luadoc ('rainbow-delimiters' | string)?
+---@field make ('rainbow-delimiters' | string)?
+---@field markdown ('rainbow-delimiters' | string)?
+---@field nim ('rainbow-delimiters' | string)?
+---@field nix ('rainbow-delimiters' | string)?
+---@field perl ('rainbow-delimiters' | string)?
+---@field php ('rainbow-delimiters' | string)?
+---@field python ('rainbow-delimiters' | string)?
+---@field query ('rainbow-delimiters' | string)?
+---@field r ('rainbow-delimiters' | string)?
+---@field racket ('rainbow-delimiters' | string)?
+---@field regex ('rainbow-delimiters' | string)?
+---@field rst ('rainbow-delimiters' | string)?
+---@field ruby ('rainbow-delimiters' | string)?
+---@field rust ('rainbow-delimiters' | string)?
+---@field scheme ('rainbow-delimiters' | string)?
+---@field scss ('rainbow-delimiters' | string)?
+---@field sql ('rainbow-delimiters' | string)?
+---@field templ ('rainbow-delimiters' | string)?
+---@field toml ('rainbow-delimiters' | string)?
+---@field tsx ('rainbow-delimiters' | 'rainbow-parens' | string)?
+---@field typescript ('rainbow-delimiters' | 'rainbow-parens' | string)?
+---@field verilog ('rainbow-delimiters' | 'rainbow-blocks' | string)?
+---@field vim ('rainbow-delimiters' | string)?
+---@field vimdoc ('rainbow-delimiters' | string)?
+---@field vue ('rainbow-delimiters' | string)?
+---@field yaml ('rainbow-delimiters' | string)?
+---@field zig ('rainbow-delimiters' | string)?
+---User defined language, not part of rainbow_delimiters support
+---@field [string] string?
+
+---@alias rainbow_delimiters.language
+---| 'astro'
+---| 'bash'
+---| 'c'
+---| 'c_sharp'
+---| 'clojure'
+---| 'commonlisp'
+---| 'cpp'
+---| 'css'
+---| 'cuda'
+---| 'cue'
+---| 'dart'
+---| 'elixir'
+---| 'elm'
+---| 'fennel'
+---| 'fish'
+---| 'go'
+---| 'haskell'
+---| 'hcl'
+---| 'html'
+---| 'janet_simple'
+---| 'java'
+---| 'javascript'
+---| 'json'
+---| 'json5'
+---| 'jsonc'
+---| 'jsonnet'
+---| 'julia'
+---| 'kotlin'
+---| 'latex'
+---| 'lua'
+---| 'luadoc'
+---| 'make'
+---| 'markdown'
+---| 'nim'
+---| 'nix'
+---| 'perl'
+---| 'php'
+---| 'python'
+---| 'query'
+---| 'r'
+---| 'racket'
+---| 'regex'
+---| 'rst'
+---| 'ruby'
+---| 'rust'
+---| 'scheme'
+---| 'scss'
+---| 'sql'
+---| 'templ'
+---| 'toml'
+---| 'tsx'
+---| 'typescript'
+---| 'verilog'
+---| 'vim'
+---| 'vimdoc'
+---| 'vue'
+---| 'yaml'
+---| 'zig'
+---User defined language, not part of rainbow_delimiters support
+---| string
+
+---@class (exact) rainbow_delimiters.logging
+---@field file ('rainbow_delimiters.log' | string)?
+---@field level integer

--- a/lua/rainbow-delimiters/default.lua
+++ b/lua/rainbow-delimiters/default.lua
@@ -15,6 +15,7 @@
 --]]
 
 ---Default plugin configuration.
+---@type rainbow_delimiters.config
 local M = {
 	---Query names by file type
 	query = {

--- a/lua/rainbow-delimiters/health.lua
+++ b/lua/rainbow-delimiters/health.lua
@@ -31,6 +31,8 @@ local schema = {
 
 
 ---Check whether there is a parser installed for the given language.
+---@param lang string
+---@return boolean
 local function check_parser_installed(lang)
 	local success = pcall(vim.treesitter.language.inspect, lang)
 	return success
@@ -41,6 +43,8 @@ end
 ---This is not a 100% reliable check; we only test the type of the argument and
 ---whether the table has the correct fields, but not what the callback
 ---functions actually do.
+---@param strategy rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?
+---@return boolean
 local function check_strategy(strategy)
 	if type(strategy) == 'function' then
 		local finfo = debug.getinfo(strategy)
@@ -62,14 +66,20 @@ local function check_strategy(strategy)
 end
 
 ---Check whether the given query is defined for the given language.
+---@param lang string
+---@param name string
+---@return boolean
 local function check_query(lang, name)
 	local query = vim.treesitter.query.get(lang, name)
 	return query ~= nil
 end
 
+---@param settings rainbow_delimiters.logging
 local function check_logging(settings)
 	local level, file = settings.level, settings.file
 	if level then
+		-- Note: although the log level is an integer, Lua 5.1 only has the
+		-- number type
 		if type(level) ~= 'number' then
 			error('The log level must be a number', 'See :h vim.log.levels for valid log levels.')
 		else
@@ -102,7 +112,7 @@ end
 
 
 function M.check()
-	local settings = vim.g.rainbow_delimiters
+	local settings = vim.g.rainbow_delimiters --[[@as rainbow_delimiters.config]]
 	if not settings then
 		return
 		info("No custom configuration; see :h rb-delimiters-setup for information.")

--- a/lua/rainbow-delimiters/log.lua
+++ b/lua/rainbow-delimiters/log.lua
@@ -30,6 +30,7 @@ end
 
 ---Dynamically determines the module from which the log function was called.
 ---If it was called from somewhere else return the name of the plugin.
+---@return string
 local function get_module()
 	local module = debug.getinfo(4, 'S').source:match('^.+rainbow%-delimiters/(.+).lua$')
 	if not module then
@@ -38,6 +39,11 @@ local function get_module()
 	return module:gsub('/', '.')
 end
 
+---@param file file*
+---@param level integer
+---@param module string
+---@param message any
+---@param ... any
 local function write_log(file, level, module, message, ...)
 	local msg
 	local timestamp = date('%FT%H:%M%z')
@@ -50,6 +56,9 @@ local function write_log(file, level, module, message, ...)
 	file:write(string.format('%s	%s	%s	%s\n', timestamp, level, module, msg))
 end
 
+---@param level integer
+---@param message any
+---@param ... any
 local function log(level, message, ...)
 	if level < config.log.level then return end
 

--- a/lua/rainbow-delimiters/setup.lua
+++ b/lua/rainbow-delimiters/setup.lua
@@ -3,7 +3,7 @@ local M = {}
 ---Apply the given configuration to the rainbow-delimiter settings.  Will
 ---overwrite existing settings.
 ---
----@param opts table  Settings, same format as `vim.g.rainbow_delimiters`
+---@param opts rainbow_delimiters.config  Settings, same format as `vim.g.rainbow_delimiters`
 function M.setup(opts)
 	vim.g.rainbow_delimiters = opts
 end

--- a/lua/rainbow-delimiters/stack.lua
+++ b/lua/rainbow-delimiters/stack.lua
@@ -17,18 +17,22 @@
 ---Helper library for stack-like tables.
 local M = {}
 
----@class Stack
----@field public  size    fun(self: Stack): number
+---@class (exact) Stack
+---@field public  size    fun(self: Stack): integer
 ---@field public  peek    fun(self: Stack): any
 ---@field public  push    fun(self: Stack, item: any): Stack
 ---@field public  pop     fun(self: Stack): any
----@field public  iter    fun(self: Stack): (fun(i: number, item: any): number, any), Stack, number
----@field private content any[]
+---@field public  iter    fun(self: Stack): ((fun(i: integer, item: any): integer?, any), Stack, integer)
+---@field package content any[]
 
 ---The stack metatable.
 local mt = {}
 
 ---The actual iterator implementation, hidden behind the iter-method.
+---@param stack Stack
+---@param i integer
+---@return integer?
+---@return any
 local function iter_stack(stack, i)
 	if i <= 1 then return end
 	return i - 1, stack.content[i - 1]
@@ -39,7 +43,7 @@ end
 local function stack_tostring(stack)
 	local items = {}
 	for _, item in ipairs(stack.content) do
-		items[#items+1] = tostring(item)
+		items[#items + 1] = tostring(item)
 	end
 	return string.format('[%s]', table.concat(items, ', '))
 end
@@ -48,7 +52,8 @@ end
 ---[ Methods ]-----------------------------------------------------------------
 
 ---Returns the current number of items in the stack.
----@return number size  Current size of the stack
+---@param self Stack
+---@return integer size  Current size of the stack
 local function size(self)
 	return #self.content
 end
@@ -57,9 +62,9 @@ end
 ---returns the current index (one-based, counting from the bottom) and the
 ---current item.
 ---@param self Stack  The stack instance
----@return fun(i: number, stack: Stack): number, any
+---@return fun(i: integer, stack: Stack): integer?, any
 ---@return Stack
----@return number
+---@return integer
 local function iter(self)
 	return iter_stack, self, self:size() + 1
 end
@@ -98,12 +103,12 @@ end
 function M.new(items)
 	---@type Stack
 	local result = {
-		content = {},  ---@type any[]
-		size = size,   ---@type fun(self: Stack): number
-		iter = iter,
-		push = push,   ---@type fun(self: Stack, item: any): Stack
-		pop  = pop,    ---@type fun(self: Stack): any
-		peek = peek,   ---@type fun(self: Stack): any
+		content = {},
+		size    = size,
+		iter    = iter,
+		push    = push,
+		pop     = pop,
+		peek    = peek,
 	}
 	setmetatable(result, mt)
 	for _, item in ipairs(items or {}) do result:push(item) end

--- a/lua/rainbow-delimiters/strategy/local.lua
+++ b/lua/rainbow-delimiters/strategy/local.lua
@@ -45,11 +45,15 @@ local M = {}
 local match_trees = {}
 
 ---Reusable autogroup for events in this strategy.
----@type number
+---@type integer
 local augroup = api.nvim_create_augroup('TSRainbowLocalCursor', {})
 
 
 ---Highlights a single match with the given highlight group
+---@param bufnr integer
+---@param lang string
+---@param match table
+---@param hlgroup string
 local function highlight_match(bufnr, lang, match, hlgroup)
 	for _, delimiter in match.delimiter:iter() do lib.highlight(bufnr, lang, delimiter, hlgroup) end
 end
@@ -57,9 +61,9 @@ end
 ---Highlights all matches and their children on the stack of matches. All
 ---matches must be on the same level of the match tree.
 ---
----@param bufnr   number  Number of the buffer
+---@param bufnr   integer  Number of the buffer
 ---@param matches Stack   Stack of matches
----@param level   number  Level of the matches
+---@param level   integer  Level of the matches
 local function highlight_matches(bufnr, lang, matches, level)
 	local hlgroup = lib.hlgroup_at(level)
 	for _, match in matches:iter() do
@@ -70,6 +74,13 @@ end
 
 ---Finds a match (and its level) in the match tree whose container node is the
 ---given container node.
+---@param matches Stack
+---@param container TSNode
+---@param level integer
+---@return table
+---@return integer
+---If no match is found, return nil.
+---@overload fun(matches: Stack, container: TSNode, level: integer)
 local function find_container(matches, container, level)
 	for _, match in matches:iter() do
 		if match.container == container then return match, level end
@@ -79,7 +90,7 @@ local function find_container(matches, container, level)
 end
 
 --- Create a new empty match_record with an optionally set container
----@param container TSNode?
+---@param container TSNode
 ---@return table
 local function new_match_record(container)
 	return {
@@ -91,7 +102,7 @@ end
 
 ---Assembles the match tree, usually called after the document tree has
 ---changed.
----@param bufnr   number  Buffer number
+---@param bufnr   integer  Buffer number
 ---@param changes table   List of node ranges in which the changes occurred
 ---@param tree    TSTree  TS tree
 ---@param lang    string  Language
@@ -164,6 +175,9 @@ local function build_match_tree(bufnr, changes, tree, lang)
 	return matches
 end
 
+---@param bufnr integer
+---@param tree TSTree
+---@param lang string
 local function update_local(bufnr, tree, lang)
 	if not lib.enabled_for(lang) then return end
 	local query = lib.get_query(lang)
@@ -218,6 +232,8 @@ end
 
 ---Callback function to re-highlight the buffer according to the current cursor
 ---position.
+---@param bufnr integer
+---@param parser LanguageTree
 local function local_rainbow(bufnr, parser)
 	parser:for_each_tree(function(tree, sub_parser)
 		update_local(bufnr, tree, sub_parser:lang())
@@ -225,9 +241,8 @@ local function local_rainbow(bufnr, parser)
 end
 
 ---Sets up all the callbacks and performs an initial highlighting
----@param bufnr number # Buffer number
+---@param bufnr integer # Buffer number
 ---@param parser LanguageTree
----@return nil
 local function setup_parser(bufnr, parser)
 	log.debug('Setting up parser for buffer %d', bufnr)
 	util.for_each_child(nil, parser:lang(), parser, function(p, lang, _parent_lang)
@@ -236,6 +251,8 @@ local function setup_parser(bufnr, parser)
 		-- nil-reference error
 		if not lib.get_query(lang) then return end
 		p:register_cbs {
+			---@param _changes table
+			---@param tree TSTree
 			on_changedtree = function(_changes, tree)
 				-- HACK: As of Neovim v0.9.1 there is no way of unregistering a
 				-- callback, so we use this check to abort
@@ -255,6 +272,7 @@ local function setup_parser(bufnr, parser)
 			end,
 			-- New languages can be added into the text at some later time, e.g.
 			-- code snippets in Markdown
+			---@param child LanguageTree
 			on_child_added = function(child)
 				setup_parser(bufnr, child)
 			end,
@@ -263,6 +281,9 @@ local function setup_parser(bufnr, parser)
 	end)
 end
 
+---on_attach implementation for the local strategy
+---@param bufnr integer
+---@param settings rainbow_delimiters.buffer_settings
 function M.on_attach(bufnr, settings)
 	local parser = settings.parser
 	setup_parser(bufnr, parser)
@@ -291,6 +312,8 @@ function M.on_attach(bufnr, settings)
 	local_rainbow(bufnr, parser)
 end
 
+---on_detach implementation for the local strategy
+---@param bufnr integer
 function M.on_detach(bufnr)
 	-- Uninstall autocommand and delete cached match tree
 	api.nvim_clear_autocmds {
@@ -300,11 +323,14 @@ function M.on_detach(bufnr)
 	match_trees[bufnr] = nil
 end
 
+---on_reset implementation for the local strategy
+---@param bufnr integer
+---@param settings rainbow_delimiters.buffer_settings
 function M.on_reset(bufnr, settings)
 	local parser = settings.parser
 	local_rainbow(bufnr, parser)
 end
 
-return M
+return M --[[@as rainbow_delimiters.strategy]]
 
 -- vim:tw=79:ts=4:sw=4:noet:

--- a/lua/rainbow-delimiters/strategy/no-op.lua
+++ b/lua/rainbow-delimiters/strategy/no-op.lua
@@ -17,15 +17,23 @@
 ---A dummy strategy which does nothing; can be used in testing.
 local M = {}
 
-M.on_attach = function()
+---on_attach implementation for the noop strategy
+---@param _bufnr integer
+---@param _settings rainbow_delimiters.buffer_settings
+M.on_attach = function(_bufnr, _settings)
 end
 
-M.on_detach = function()
+---on_detach implementation for the noop strategy
+---@param _bufnr integer
+M.on_detach = function(_bufnr)
 end
 
-M.on_reset = function()
+---on_reset implementation for the noop strategy
+---@param _bufnr integer
+---@param _settings rainbow_delimiters.buffer_settings
+M.on_reset = function(_bufnr, _settings)
 end
 
-return M
+return M --[[@as rainbow_delimiters.strategy]]
 
 -- vim:tw=79:ts=4:sw=4:noet:

--- a/lua/rainbow-delimiters/util.lua
+++ b/lua/rainbow-delimiters/util.lua
@@ -28,8 +28,7 @@ local M = {}
 ---@param parent_lang string? # Parent language or nil
 ---@param lang string
 ---@param language_tree LanguageTree
----@param thunk fun(p: LanguageTree, lang: string, parent_lang: string?): nil
----@return nil
+---@param thunk fun(p: LanguageTree, lang: string, parent_lang: string?)
 function M.for_each_child(parent_lang, lang, language_tree, thunk)
 	thunk(language_tree, lang, parent_lang)
 	local children = language_tree:children()


### PR DESCRIPTION
I added a lot of type information, so we can get proper LSP information when setting up the plugin:

<img width="477" alt="Screenshot 2023-11-11 at 17 42 35" src="https://github.com/HiPhish/rainbow-delimiters.nvim/assets/7075380/c0b645d9-53b3-4928-887a-0d43e410feb9">

<img width="468" alt="Screenshot 2023-11-11 at 17 43 05" src="https://github.com/HiPhish/rainbow-delimiters.nvim/assets/7075380/3ce135fc-79fe-4382-843b-f56bab5ff0c0">

<img width="508" alt="Screenshot 2023-11-11 at 17 43 24" src="https://github.com/HiPhish/rainbow-delimiters.nvim/assets/7075380/f3cba3d7-4a6f-4573-b228-38364d9207e0">

<img width="463" alt="Screenshot 2023-11-11 at 17 43 46" src="https://github.com/HiPhish/rainbow-delimiters.nvim/assets/7075380/58e25b83-c685-434b-a07e-156640019100">

I also made a few other small edits that might be worth discussing. Here is a list of things to think about before this is ready to be committed:

- [x] Right now I allow random strings in place of a known language, strategy, highlight color or query. This is because a user of the plugin could define their own, but this also means that the LSP won't really help out with spelling mistakes, since e.g. `vim` misspelled as `vin` is still a string. We could change this or see if there is some good workaround. (Spelling mistakes will be caught by `:checkhealth`, so we should be good with the current code.)
- [x] Since we don't want `setup` in `rainbow-delimiters.lua`, I have added an `__index` meta method for now. This is a temporary solution, that I think should make lazy work as expected, but I am not sure if that is a good solution. I assume you would still like to avoid putting `setup` in `rainbow-delimiters.lua`? (Think about this later.)
- [x] I think the standard for Neovim is to use `integer` instead of `number` for stuff like `bufnr` (or anything else that you know is an integer). Do you want to change `number` to `integer` or leave it as it is now? (Yes, use `integer`.)
- [x] I added `'comment'` to the blacklist, since that seems like a good idea based on #53. I can remove it again, if you prefer? (Remove it for now and instead investigate why `comment` causes problems.)

Other notes:
- If you ever do a rewrite, note that it is easier to give types for strings that don't need to be inside `['<name>']` in a Lua table (like `['local']` or `['']`).
- I couldn't figure out a way for the plugin to capture the fact that the type of `vim.g.rainbow_delimiters` should be of type `rainbow_delimiters.config`. So for now a user of the plugin will have to add `---@type rainbow_delimiters.config` before `vim.g.rainbow_delimiters` to get the LSP to work as expected. I have added this to the docs for now, but we can remove it if we figure out how to avoid this step. If you use the setup function the type is already correct now without the user adding anything. 
- I haven't figured out a way to remove used strings from the arrays with strings (like highlight or blacklist). So for those the LSP will continue to suggest a string that has already been used right now, but this should be easy enough to work with still. 