### PR TITLE
Very minor cleanup

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,10 +15,10 @@ manual first to understand how to write queries.  Your query should meet the
 following criteria:
 
 - Named `rainbow-delimiters`
-- Few if any `@intermediate` capture groups; we do not want the default query
-  to be too vibrant
+- Few `@delimiter` capture groups per `@container`; we do not want the default
+  query to be too vibrant
 - Write one or more files in the language under `test/highlight/<lang>` (where
-  `<lang>` is the language)
+  `<lang>` is the language); the standard file name is `regular.<ext>`
 - The test code must have at least one instance of each pattern in the query
 - The test code must not have parsing errors
 - The test code should ideally have multiple levels of nesting
@@ -26,4 +26,4 @@ following criteria:
   (this is not a hard rule though)
 
 If there are many test cases or if the code becomes too verbose feel free to
-created multiple test files.
+create multiple test files.

--- a/doc/rainbow-delimiters.txt
+++ b/doc/rainbow-delimiters.txt
@@ -5,7 +5,7 @@
 
 Author: Alejandro "HiPhish" Sanchez
 License: Apache-2.0
-Version: 0.0.0
+Version: 0.1.0
 
 
 ==============================================================================


### PR DESCRIPTION
I noticed that `CONTRIBUTING.rst` still said `@intermediate` instead of `@delimiter`.

Also, I remember discussing updating the version number after the big update. I added it here mainly as a reminder, but I can just remove it again if you prefer. 