### PR TITLE
Add comment on `html-tag-names` queries

### DIFF
--- a/queries/html/rainbow-delimiters.scm
+++ b/queries/html/rainbow-delimiters.scm
@@ -1,6 +1,14 @@
 ;;; A pair of delimiter tags with any content in-between.
 ;;; Last tag should be a sentinel.
 
+;;; If instead you want rainbow-delimiters to only highlight
+;;; the tag names without any of "<", "</", ">" or "/>", then
+;;; you can make your own query file, e.g.,
+;;;   'rainbow-tag-names'
+;;; and use the following with
+;;;   x @delimiter
+;;; deleted for x equal to any of "<", "</", ">" or "/>".
+
 (element
   (start_tag
     "<" @delimiter


### PR DESCRIPTION
I saw a [request to be able to keep the old style html highlighting](https://www.reddit.com/r/neovim/comments/17tiq3a/big_change_to_rainbowdelimitersnvim/) on reddit, so I thought I would add it. Please let me know if you have a better name for it.