### PR TITLE
Bug fix - fixes #59

### DIFF
--- a/lua/rainbow-delimiters/strategy/local.lua
+++ b/lua/rainbow-delimiters/strategy/local.lua
@@ -195,7 +195,9 @@ local function update_local(bufnr, tree, lang)
 	end
 	local matches = matches_lang[tree]
 	if not matches then
-		log.debug("Did not build any matches Stack for tree '%s'", vim.inspect(tree:root():range()))
+		-- Note: vim.inspect(tree:root():range()) errors, so we need
+		-- to make it into a table instead of a list of numbers
+		log.debug("Did not build any matches Stack for tree '%s'", vim.inspect( {tree:root():range()} ))
 		return
 	end
 
@@ -285,7 +287,7 @@ function M.on_attach(bufnr, settings)
 		local changes = {
 			{tree:root():range()}
 		}
-		match_trees[bufnr][sub_lang] = {}
+		match_trees[bufnr][sub_lang] = match_trees[bufnr][sub_lang] or {}
 		match_trees[bufnr][sub_lang][tree] = build_match_tree(bufnr, changes, tree, sub_lang)
 	end)
 	local_rainbow(bufnr, parser)

--- a/test/highlight/c/regular.c
+++ b/test/highlight/c/regular.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+#define MACRO 0
+
 /* A function declaration */
 int add(int, int);
 


### PR DESCRIPTION
The previous fix for #59 fixed the first error, but there was another problem. I tracked down the following error to two things:

1. `vim.inspect` has a problem that causes an error on `vim.inspect(tree:root():range())`. Using a table instead fixes this error, i.e., `vim.inspect( {tree:root():range()} )`.
2. The local strategy's `on_attach` had a typo, where we accidentally reset a table that we wanted to keep if it exists. 

This code should fix both of those problems. 

Additionally I added a `#define` statement to the test file for c, since that was what caused this problem to show up (because it creates another tree in the same language in 0.9.4). 