### PR TITLE
Add luadoc queries

### DIFF
--- a/queries/luadoc/rainbow-delimiters.scm
+++ b/queries/luadoc/rainbow-delimiters.scm
@@ -1,0 +1,39 @@
+(function_type
+  "(" @delimiter
+  ")" @delimiter @sentinel
+) @container
+
+(parenthesized_type
+  "(" @delimiter
+  ")" @delimiter @sentinel
+) @container
+
+;;; I wanted to use something like
+; (union_type
+;   "|" @delimiter @sentinel
+; ) @container
+;;; too, but it doesn't fully work with the current parser
+
+(array_type
+  "[" @delimiter
+  "]" @delimiter @sentinel
+) @container
+
+(table_type
+  "<" @delimiter
+  ">" @delimiter @sentinel
+) @container
+
+(table_literal_type
+  "{" @delimiter
+  "}" @delimiter @sentinel
+) @container
+
+(_
+  "[" @delimiter
+  .
+  field: (_)
+  .
+  "]" @delimiter @sentinel
+) @container
+

--- a/test/highlight/luadoc/regular.lua
+++ b/test/highlight/luadoc/regular.lua
@@ -1,0 +1,25 @@
+---@type fun(x: (fun(): integer), y: fun(z: fun()))
+
+---@type { key1: { key2: { [string]: table<number, number | integer> }, [integer]: integer } }
+
+---@type table<integer | number, table<string, table<number, boolean>>>
+
+---@class test
+---@field a boolean
+---@field b (((boolean)))
+---@field x number | string | { key: number | string | boolean } | boolean
+-- This is not yet supported by the luadoc parser:
+---@field [string] boolean
+
+---@type string[]
+local _str_tbl = { 'a', 'b', 'c' }
+
+-- Note: The parser nests union types, which can mess
+-- with rainbow-delimiters highlighting, so we don't
+-- highlight the '|' here:
+---@type number | integer[] | string | number[] | string[] | boolean | boolean[]
+local _x = 1
+---@type boolean[] | integer[]
+local _t = { true, false } or { 0, 1 }
+---@type (boolean | integer)[]
+local _arr = { true, 0 }


### PR DESCRIPTION
The luadoc parser has a few problems with things it captures weirdly (or doesn't really capture), but we can get good highlighting for most type annotations in Lua with this. 

Note: If you commit this before the update with types, then I can add `luadoc` there. Otherwise, if you commit the types update first, I can rebase this pull request and add the types here. 