### PR TITLE
feat(query): add query for identifier

### DIFF
--- a/queries/query/rainbow-delimiters.scm
+++ b/queries/query/rainbow-delimiters.scm
@@ -1,5 +1,6 @@
 (named_node
   "(" @delimiter
+  (identifier) @delimiter
   ")" @delimiter @sentinel) @container
 
 (grouping


### PR DESCRIPTION
I see that it is very hard to keep track of the multiple levels of query identifiers. I created them because HTML, JSX, and TSX all have repeating elements and you use rainbow for it by default.

Demo:
![image](https://github.com/HiPhish/rainbow-delimiters.nvim/assets/26183671/3f01d854-2b63-4b00-89f8-dbba7376c2f9)
