### PR TITLE
Minor docs cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,9 @@ same parameters as `g:rainbow-delimiters`.
        query = {
            -- ...
        },
+       priority = {
+           -- ...
+       },
        highlight = {
            -- ...
        },

--- a/TODO.rst
+++ b/TODO.rst
@@ -5,15 +5,6 @@
 #######################
 
 
-Built-in queries
-################
-
-As of version 0.8.3 Neovim can only match one node per query.  This is a
-limitation of Neovim and there is nothing that can be done on this end.
-
-The global query does not updated the highlighting of injected languages.
-
-
 Queries which I cannot port
 ===========================
 
@@ -21,10 +12,8 @@ I do not know enough about the following languages in order to write good
 queries.  Contributions are welcome.
 
 - devicetree
-- elm
 - gdscript
 - graphql
-- kotlin
 - meson
 - ocaml
 - ocaml_interface

--- a/doc/rainbow-delimiters.txt
+++ b/doc/rainbow-delimiters.txt
@@ -160,6 +160,10 @@ available as part of a Lua module.
             [''] = 'rainbow-delimiters',
             latex = 'rainbow-blocks',
         },
+        priority = {
+            [''] = 110,
+            lua = 210,
+        },
         highlight = {
             'RainbowDelimiterRed',
             'RainbowDelimiterYellow',
@@ -617,7 +621,7 @@ In HTML the terminating slash in a self-closing tag is optional.  Instead of
     (element
       (start_tag
         "<" @delimiter
-        (tag_name) @delimiter @_tag_name
+        (tag_name) @delimiter
         ">" @delimiter @sentinel)) @container
 <
 However, this query also matches the opening tag of regular tags like `<div>`.


### PR DESCRIPTION
I added `priority` in a few examples to make it look more like the other examples and then I removed a `@_tag_name` in an example (it should only be in the example after the one I removed). 

Also, I removed stuff from the `TODO.rst` that doesn't seem to be true anymore.