### PR TITLE
Add `rainbow-blocks` to `query` and allow query setup via a function

### DIFF
--- a/doc/rainbow-delimiters.txt
+++ b/doc/rainbow-delimiters.txt
@@ -293,15 +293,32 @@ QUERIES                                                  *rb-delimiters-query*
 A query defines what to match.  Every language needs its own custom query.
 The query setting is a table where each entry maps a language name to a query
 name.  The empty string is the key for the default query.
+
+Each value in the table can be either the name of a query file or a function of
+zero arguments which evaluates to the name of a query file (a so-called
+"thunk").  A function can be used to defer the decision to a later
+point in time.
 >lua
     -- Use parentheses by default, blocks for Lua
     query = {
         [''] = 'rainbow-delimiters',
         lua = 'rainbow-blocks',
+        query = function()
+            if vim.b.dev_base then
+                -- if we are in `InspectTree`
+                return 'rainbow-blocks'
+            else
+                -- if we are not in `InspectTree`
+                return 'rainbow-delimiters'
+            end
+        end
     }
 <
 If you wish to define your own custom query or add support for a new language,
 consult |rb-delimiters-custom-query| for details.
+
+(Note: `b:dev_base` is not a documented variable, so it might change in the
+future.)
 
 For every language the query `rainbow-delimiters` is defined, which matches a
 reasonable set of parentheses and similar delimiters for each language.  In
@@ -316,6 +333,9 @@ addition there are the following extra queries for certain languages:
   - `rainbow-delimiters-react` Includes React support, set by default for
     Javascript files
   - `rainbow-parens` Only parentheses without React tags
+- `query`
+  - `rainbow-blocks` Highlight named nodes and identifiers in addition to
+    parentheses (useful for `InspectTree`)
 - `tsx`
   - `rainbow-parens` Just Typescript highlighting without React tags
 - `typescript`

--- a/lua/rainbow-delimiters.types.lua
+++ b/lua/rainbow-delimiters.types.lua
@@ -103,68 +103,68 @@
 ---@field [string]     (rainbow_delimiters.strategy | fun(): rainbow_delimiters.strategy?)?
 
 ---@class rainbow_delimiters.config.queries
----@field ['']         ('rainbow-delimiters' | string)?
----@field astro        ('rainbow-delimiters' | string)?
----@field bash         ('rainbow-delimiters' | string)?
----@field c            ('rainbow-delimiters' | string)?
----@field c_sharp      ('rainbow-delimiters' | string)?
----@field clojure      ('rainbow-delimiters' | string)?
----@field commonlisp   ('rainbow-delimiters' | string)?
----@field cpp          ('rainbow-delimiters' | string)?
----@field css          ('rainbow-delimiters' | string)?
----@field cuda         ('rainbow-delimiters' | string)?
----@field cue          ('rainbow-delimiters' | string)?
----@field dart         ('rainbow-delimiters' | string)?
----@field elixir       ('rainbow-delimiters' | string)?
----@field elm          ('rainbow-delimiters' | string)?
----@field fennel       ('rainbow-delimiters' | string)?
----@field fish         ('rainbow-delimiters' | string)?
----@field go           ('rainbow-delimiters' | string)?
----@field haskell      ('rainbow-delimiters' | string)?
----@field hcl          ('rainbow-delimiters' | string)?
----@field html         ('rainbow-delimiters' | string)?
----@field janet_simple ('rainbow-delimiters' | string)?
----@field java         ('rainbow-delimiters' | string)?
----@field javascript   ('rainbow-delimiters' | 'rainbow-parens' | 'rainbow-delimiters-react' | string)?
----@field json         ('rainbow-delimiters' | string)?
----@field json5        ('rainbow-delimiters' | string)?
----@field jsonc        ('rainbow-delimiters' | string)?
----@field jsonnet      ('rainbow-delimiters' | string)?
----@field julia        ('rainbow-delimiters' | string)?
----@field kotlin       ('rainbow-delimiters' | string)?
----@field latex        ('rainbow-delimiters' | 'rainbow-blocks' | string)?
----@field lua          ('rainbow-delimiters' | 'rainbow-blocks' | string)?
----@field luadoc       ('rainbow-delimiters' | string)?
----@field make         ('rainbow-delimiters' | string)?
----@field markdown     ('rainbow-delimiters' | string)?
----@field nim          ('rainbow-delimiters' | string)?
----@field nix          ('rainbow-delimiters' | string)?
----@field perl         ('rainbow-delimiters' | string)?
----@field php          ('rainbow-delimiters' | string)?
----@field python       ('rainbow-delimiters' | string)?
----@field query        ('rainbow-delimiters' | string)?
----@field r            ('rainbow-delimiters' | string)?
----@field racket       ('rainbow-delimiters' | string)?
----@field regex        ('rainbow-delimiters' | string)?
----@field rst          ('rainbow-delimiters' | string)?
----@field ruby         ('rainbow-delimiters' | string)?
----@field rust         ('rainbow-delimiters' | string)?
----@field scheme       ('rainbow-delimiters' | string)?
----@field scss         ('rainbow-delimiters' | string)?
----@field sql          ('rainbow-delimiters' | string)?
----@field templ        ('rainbow-delimiters' | string)?
----@field terraform    ('rainbow-delimiters' | string)?
----@field toml         ('rainbow-delimiters' | string)?
----@field tsx          ('rainbow-delimiters' | 'rainbow-parens' | string)?
----@field typescript   ('rainbow-delimiters' | 'rainbow-parens' | string)?
----@field verilog      ('rainbow-delimiters' | 'rainbow-blocks' | string)?
----@field vim          ('rainbow-delimiters' | string)?
----@field vimdoc       ('rainbow-delimiters' | string)?
----@field vue          ('rainbow-delimiters' | string)?
----@field yaml         ('rainbow-delimiters' | string)?
----@field zig          ('rainbow-delimiters' | string)?
+---@field ['']         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field astro        (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field bash         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field c            (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field c_sharp      (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field clojure      (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field commonlisp   (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field cpp          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field css          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field cuda         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field cue          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field dart         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field elixir       (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field elm          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field fennel       (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field fish         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field go           (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field haskell      (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field hcl          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field html         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field janet_simple (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field java         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field javascript   (('rainbow-delimiters' | 'rainbow-parens' | 'rainbow-delimiters-react' | string) | fun(): ('rainbow-delimiters' | 'rainbow-parens' | 'rainbow-delimiters-react' | string))?
+---@field json         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field json5        (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field jsonc        (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field jsonnet      (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field julia        (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field kotlin       (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field latex        (('rainbow-delimiters' | 'rainbow-blocks' | string) | fun(): ('rainbow-delimiters' | 'rainbow-blocks' | string))?
+---@field lua          (('rainbow-delimiters' | 'rainbow-blocks' | string) | fun(): ('rainbow-delimiters' | 'rainbow-blocks' | string))?
+---@field luadoc       (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field make         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field markdown     (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field nim          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field nix          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field perl         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field php          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field python       (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field query        (('rainbow-delimiters' | 'rainbow-blocks' | string) | fun(): ('rainbow-delimiters' | 'rainbow-blocks' | string))?
+---@field r            (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field racket       (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field regex        (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field rst          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field ruby         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field rust         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field scheme       (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field scss         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field sql          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field templ        (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field terraform    (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field toml         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field tsx          (('rainbow-delimiters' | 'rainbow-parens' | string) | fun(): ('rainbow-delimiters' | 'rainbow-parens' | string))?
+---@field typescript   (('rainbow-delimiters' | 'rainbow-parens' | string) | fun(): ('rainbow-delimiters' | 'rainbow-parens' | string))?
+---@field verilog      (('rainbow-delimiters' | 'rainbow-blocks' | string) | fun(): ('rainbow-delimiters' | 'rainbow-blocks' | string))?
+---@field vim          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field vimdoc       (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field vue          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field yaml         (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
+---@field zig          (('rainbow-delimiters' | string) | fun(): ('rainbow-delimiters' | string))?
 ---User defined language, not part of rainbow_delimiters support
----@field [string]     string?
+---@field [string]     (string | fun(): string)?
 
 ---@class rainbow_delimiters.config.priorities
 ---@field ['']         (integer | fun(): integer?)?

--- a/lua/rainbow-delimiters/lib.lua
+++ b/lua/rainbow-delimiters/lib.lua
@@ -68,6 +68,9 @@ M.buffers = {}
 ---@return Query? query  The query object
 function M.get_query(lang)
 	local name = config['query'][lang]
+	if type(name) == "function" then
+		name = name()
+	end
 	local query = get_query(lang, name)
 
 	if not query then
@@ -88,10 +91,14 @@ function M.highlight(bufnr, lang, node, hlgroup)
 	local startRow, startCol, endRow, endCol = node:range()
 
 	local start, finish = {startRow, startCol}, {endRow, endCol - 1}
+	local priority = config.priority[lang]
+	if type(priority) == "function" then
+		priority = priority()
+	end
 	local opts = {
 		regtype = 'c',
 		inclusive = true,
-		priority = config.priority[lang],
+		priority = priority,
 	}
 
 	local nsid = M.nsids[lang]

--- a/queries/query/rainbow-blocks.scm
+++ b/queries/query/rainbow-blocks.scm
@@ -1,0 +1,28 @@
+;; Note: These queries are very useful when looking at a large
+;; tree of queries like in `InspectTree`
+(named_node
+  "(" @delimiter
+  (identifier) @delimiter
+  ")" @delimiter @sentinel) @container
+
+(grouping
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(list
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(predicate
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(field_definition
+  (identifier) @delimiter @sentinel) @container
+
+;; For more highlighting the following can be added too:
+; (parameters
+;   (identifier) @delimiter @sentinel) @container
+;
+; (negated_field
+;   (identifier) @delimiter @sentinel) @container


### PR DESCRIPTION
## Note
This PR doesn't depend on recent neovim updates, but it will be much more useful with the following:

- neovim/neovim/pull/26274 (already merged)
- neovim/neovim/pull/26304 (already merged)


## Explanation

I looked at #68 and thought something like that might be nice for `InspectTree`, so I added the following:

- `rainbow-blocks` for `query` (I only use this for `InspectTree`, where I think it looks nice and is helpful)
- I noticed that `priority` was typed as if it allowed a function, but the code didn't allow that, so I updated it. I also made it so we can setup the `query` with a function too (this is needed if I want `rainbow-blocks` in `InspectTree` and `rainbow-delimiters` in other `query` files). I think this adds a nice consistency too. 
- I updated the docs to reflect the above.

Note: There is one small problem that doesn't have anything to do with this update, see neovim/neovim/issues/26325 .

Here is an image showcasing `rainbow-delimiters` for the `query` file and `rainbow-blocks` for `InspectTree`. [ Note: this uses neovim/neovim/pull/26304 ]

<img width="1615" alt="Screenshot 2023-11-29 at 21 30 19" src="https://github.com/HiPhish/rainbow-delimiters.nvim/assets/7075380/d3c04feb-2653-4bad-9601-f17a5a416e7b">

