### PR TITLE
Add missing c query

### DIFF
--- a/queries/c/rainbow-delimiters.scm
+++ b/queries/c/rainbow-delimiters.scm
@@ -46,3 +46,6 @@
   "(" @delimiter
   ")" @delimiter @sentinel) @container
 
+(enumerator_list
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/test/highlight/c/regular.c
+++ b/test/highlight/c/regular.c
@@ -2,6 +2,13 @@
 
 #define MACRO 0
 
+typedef enum {
+  E1,
+  E2,
+  E3
+  // comment
+} Myenum;
+
 /* A function declaration */
 int add(int, int);
 


### PR DESCRIPTION
I noticed that the `c` queries were missing `enumerator_list`, so I added it. 