### PR TITLE
Add more `c` queries

### DIFF
--- a/queries/c/rainbow-delimiters.scm
+++ b/queries/c/rainbow-delimiters.scm
@@ -1,10 +1,10 @@
 (parameter_list
-   "(" @delimiter
-   ")" @delimiter @sentinel) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (argument_list
-   "(" @delimiter
-   ")" @delimiter @sentinel) @container
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
 
 (parenthesized_expression
   "(" @delimiter
@@ -26,8 +26,8 @@
   "]" @delimiter @sentinel) @container
 
 (field_declaration_list
-   "{" @delimiter
-   "}" @delimiter @sentinel) @container
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
 
 (array_declarator
   "[" @delimiter
@@ -49,3 +49,19 @@
 (enumerator_list
   "{" @delimiter
   "}" @delimiter @sentinel) @container
+
+(macro_type_specifier
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(preproc_params
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(compound_literal_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(parenthesized_declarator
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/test/highlight/c/regular.c
+++ b/test/highlight/c/regular.c
@@ -1,6 +1,19 @@
 #include <stdio.h>
 
-#define MACRO 0
+
+#define PI 3.14
+/* These aren't highlight correctly. A problem with the parser? */
+#define TESTMACRO (-1)
+#define min(X,Y) ((X) < (Y) ? (X) : (Y))
+
+
+/* Declaration with parentheses, a function pointer */
+static void (*callback)(int);
+int c_init() { return 1; }
+
+/* Macro type specifier */
+#define Map int Foo
+static Map(char *c_str) {return 4;}
 
 typedef enum {
   E1,
@@ -17,6 +30,8 @@ struct Point2D {
 	int y;
 };
 
+/* Compound literal expression */
+struct Point2D v = (struct Point2D){ 0, 0 };
 
 /* A function definition */
 int add(int x, int y) {


### PR DESCRIPTION
I found some more missing `c` queries. I don't actually know `c` that well (I just found these while going through the neovim codebase), so I can't write tests that won't have the LSP give some complaints. Feel free to edit this, if you are more used to `c` (or suggest changes and I will update it). 

Also, there is some problem with highlighting in macros (I made a comment about it in the test file). I am not sure what is wrong there and haven't had time to look into it in more details yet. 