### PR TITLE
feat: queries to highlight only jsx/tsx tags

### DIFF
--- a/doc/rainbow-delimiters.txt
+++ b/doc/rainbow-delimiters.txt
@@ -353,11 +353,13 @@ addition there are the following extra queries for certain languages:
   - `rainbow-delimiters-react` Includes React support, set by default for
     Javascript files
   - `rainbow-parens` Only parentheses without React tags
+  - `rainbow-tags-react` Only React tags without parentheses
 - `query`
   - `rainbow-blocks` Highlight named nodes and identifiers in addition to
     parentheses (useful for |:InspectTree|)
 - `tsx`
   - `rainbow-parens` Just Typescript highlighting without React tags
+  - `rainbow-tags-react` Only React tags without Typescript highlighting
 - `typescript`
   - `rainbow-parens` Just Typescript highlighting without React tags
 - `verilog`

--- a/queries/javascript/rainbow-tags-react.scm
+++ b/queries/javascript/rainbow-tags-react.scm
@@ -1,0 +1,29 @@
+(jsx_element
+  open_tag: (jsx_opening_element
+              "<" @delimiter
+              name: (identifier) @delimiter
+              ">" @delimiter)
+  close_tag: (jsx_closing_element
+               "</" @delimiter
+               name: (identifier) @delimiter
+               ">" @delimiter @sentinel)) @container
+
+(jsx_element
+  open_tag: (jsx_opening_element
+              "<" @delimiter
+              name: (member_expression) @delimiter
+              ">" @delimiter)
+  close_tag: (jsx_closing_element
+              "</" @delimiter
+               name: (member_expression) @delimiter
+              ">" @delimiter @sentinel)) @container
+
+(jsx_self_closing_element
+  "<" @delimiter
+  name: (identifier) @delimiter
+  "/>" @delimiter @sentinel) @container
+
+(jsx_self_closing_element
+  "<" @delimiter
+  name: (member_expression) @delimiter
+  "/>" @delimiter @sentinel) @container

--- a/queries/tsx/rainbow-tags-react.scm
+++ b/queries/tsx/rainbow-tags-react.scm
@@ -1,0 +1,4 @@
+; inherits: javascript
+
+;;; This query exists for people who only want to highlight tags without
+;;; parentheses.


### PR DESCRIPTION
Hello and thanks for the awesome plugin! I only use it for lisp/HTML-like languages since I find the general bracket highlights a bit distracting. But I really wanted to be able to use them for the HTML parts of JSX/TSX, so I created this PR to add a query for only the React-style tags of these files, without the main highlighting. Feel free to change this PR if needed (maybe to move from the `javascript` directory to a new `jsx` directory? I wasn't sure if maybe this would add redundant queries when using an `inherits` modeline). Thanks!