### PR TITLE
fix: Improve macro highlighting in c and cpp

### DIFF
--- a/test/highlight/cpp/regular.cpp
+++ b/test/highlight/cpp/regular.cpp
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <cstdio>
 
+#define TEST (-1)
+
 namespace herp {
 	const int derpiness = 9000;
 	int get_derpiness() {


### PR DESCRIPTION
This improves the highlighting delimiters inside c/c++ macros.

Note that this won't fix all the macro highlighting problems, since we clear namespace by row without column information. If we can limit `lib.clear_namespace` to the correct columns, then this should fix all the macro highlighting problems.

It's important that we keep the `parent_lang ~= lang` check if we want to continue having good highlighting in rust macros, and since I haven't noticed problems outside of c/c++, I guess it usually works fine with the current code. 