### PR TITLE
fix: add missing `java` delimiters

### DIFF
--- a/queries/java/rainbow-delimiters.scm
+++ b/queries/java/rainbow-delimiters.scm
@@ -34,6 +34,10 @@
   "(" @delimiter
   ")" @delimiter @sentinel) @container
 
+(annotation_argument_list
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
 (for_statement
   "(" @delimiter
   ")" @delimiter @sentinel) @container

--- a/queries/java/rainbow-delimiters.scm
+++ b/queries/java/rainbow-delimiters.scm
@@ -6,7 +6,27 @@
   "{" @delimiter
   "}" @delimiter @sentinel) @container
 
+(array_initializer
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
 (formal_parameters
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(condition
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(catch_clause 
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(parenthesized_expression 
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(inferred_parameters 
   "(" @delimiter
   ")" @delimiter @sentinel) @container
 
@@ -14,7 +34,23 @@
   "(" @delimiter
   ")" @delimiter @sentinel) @container
 
+(for_statement
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(enhanced_for_statement 
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(constructor_body
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
 (dimensions
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(dimensions_expr
   "[" @delimiter
   "]" @delimiter @sentinel) @container
 


### PR DESCRIPTION
#81 added some queries i was able to quickly find to enhance delimiters colorizing for `java`. I have no clue how treesitter queries work nor if they are performant so take it with the grain of salt