### PR TITLE
fix: java `dimensions` highlight

### DIFF
--- a/queries/java/rainbow-delimiters.scm
+++ b/queries/java/rainbow-delimiters.scm
@@ -50,12 +50,8 @@
   "{" @delimiter
   "}" @delimiter @sentinel) @container
 
-;; FIXME: This is broken for type declarations like 'Integer[][]' because both
-;; "]" will be sentinels when only the last one should be.
-(dimensions
-  "[" @delimiter
-  ("]" @delimiter "[" @delimiter)*
-  "]" @delimiter @sentinel) @container
+;; Treat it as a single delimiter because it will always have the same color
+(dimensions) @container @delimiter @sentinel
 
 (dimensions_expr
   "[" @delimiter


### PR DESCRIPTION
The workaround i found is to treat `dimensions` node as a single delimiter which will highlight it the same color.
One minor thing is that it will also highlight any text inside dimensions the same color as the delimiter but it's not grammatically correct anyway so it's not a big problem. 