### PR TITLE
feat: add git_config query

### DIFF
--- a/lua/rainbow-delimiters.types.lua
+++ b/lua/rainbow-delimiters.types.lua
@@ -55,6 +55,7 @@
 ---@field elm          (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field fennel       (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field fish         (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
+---@field git_config   (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field go           (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field haskell      (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field hcl          (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
@@ -120,6 +121,7 @@
 ---@field elm          (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field fennel       (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field fish         (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
+---@field git_config   (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field go           (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field haskell      (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field hcl          (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
@@ -185,6 +187,7 @@
 ---@field elm          (integer | fun(bufnr: integer): integer)?
 ---@field fennel       (integer | fun(bufnr: integer): integer)?
 ---@field fish         (integer | fun(bufnr: integer): integer)?
+---@field git_config   (integer | fun(bufnr: integer): integer)?
 ---@field go           (integer | fun(bufnr: integer): integer)?
 ---@field haskell      (integer | fun(bufnr: integer): integer)?
 ---@field hcl          (integer | fun(bufnr: integer): integer)?
@@ -250,6 +253,7 @@
 ---| 'elm'
 ---| 'fennel'
 ---| 'fish'
+---| 'git_config'
 ---| 'go'
 ---| 'haskell'
 ---| 'hcl'

--- a/queries/git_config/rainbow-delimiters.scm
+++ b/queries/git_config/rainbow-delimiters.scm
@@ -1,0 +1,3 @@
+(section_header
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container

--- a/test/highlight/git_config/gitconfig
+++ b/test/highlight/git_config/gitconfig
@@ -1,0 +1,14 @@
+; vim:ft=gitconfig
+[user]
+    name = JohnDoe
+    email = JohnDoe@example.com
+
+[core]
+    editor = nvim
+
+; include for all repositories inside /path/to/group
+[includeIf "gitdir:/path/to/group/"]
+	path = /path/to/foo.inc
+
+[remote "origin"]
+	url = https://example.com/git


### PR DESCRIPTION
This adds highlighting to git_config files. From what I can tell the only query needed is the included `section_header` query, since git_config files have a pretty simple syntax.