### PR TITLE
fix(rust): add missing query `array_type`

### DIFF
--- a/queries/rust/rainbow-delimiters.scm
+++ b/queries/rust/rainbow-delimiters.scm
@@ -100,6 +100,10 @@
   "[" @delimiter
   "]" @delimiter @sentinel) @container
 
+(array_type
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
 (index_expression
   "[" @delimiter
   "]" @delimiter @sentinel) @container

--- a/test/highlight/rust/regular.rs
+++ b/test/highlight/rust/regular.rs
@@ -56,6 +56,12 @@ macro_rules! inefficient_vec {
 
 pub(crate) struct VisibilityModifier;
 
+
+pub const NAMES: &'static [(&'static str, u32)] = &[
+    ("TEST NAME 1", 1),
+    ("TEST NAME 2", 2),
+];
+
 fn main() {
     let nested_vec: Vec<Vec<Vec<Vec<Vec<Vec<()>>>>>> = Vec::<_>::new();
     let arr_arr_arr = [[[0; 4]; 4]; 4];


### PR DESCRIPTION
I found a missing rust query.