### PR TITLE
Implement functions for checking if rainbow is enabled in buffer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Unreleased
 Added
 =====
 
+- Public API function `is_enabled`
 - XML support
 - Missing patterns for Java:
    - `array_initializer`

--- a/autoload/rainbow_delimiters.vim
+++ b/autoload/rainbow_delimiters.vim
@@ -41,4 +41,10 @@ function! rainbow_delimiters#toggle(bufnr)
 	call luaeval("require('rainbow-delimiters').toggle(_A)", a:bufnr)
 endfunction
 
+" Check if highlighting is enabled for the given buffer. Buffer number zero
+" means current buffer.
+function! rainbow_delimiters#is_enabled(bufnr)
+	return luaeval("require('rainbow-delimiters').is_enabled(_A)", a:bufnr)
+endfunction
+
 " vim:tw=79:ts=4:sw=4:noet:

--- a/doc/rainbow-delimiters.txt
+++ b/doc/rainbow-delimiters.txt
@@ -444,6 +444,16 @@ rainbow_delimiters#toggle({bufnr})
     Vim script binding for the above function.
 
 
+                                                    *rb-delimiters.is_enabled*
+                                                    *rb_delimiters#is_enabled*
+'rainbow-delimiters'.is_enabled({bufnr})
+    Check if rainbow delimiters are enabled for the buffer {bufnr} (or the
+    current buffer if {bufnr} is `0`).
+
+rainbow_delimiters#is_enabled({bufnr})
+    Vim script binding for the above function.
+
+
                                                     *rb-delimiters.hlgroup_at*
                                                *rainbow-delimiters#hlgroup_at*
 'rainbow-delimiters'.hlgroup_at({nesting_level})

--- a/lua/rainbow-delimiters.lua
+++ b/lua/rainbow-delimiters.lua
@@ -44,6 +44,14 @@ local function toggle(bufnr)
 	end
 end
 
+---Check if rainbow delimiters are enabled for a given buffer.
+---@param bufnr integer  Buffer number, zero for current buffer.
+---@return boolean # Whether or not rainbow delimiters is enabled
+local function is_enabled(bufnr)
+	if not bufnr or bufnr == 0 then bufnr = vim.api.nvim_get_current_buf() end
+	return lib.buffers[bufnr] ~= nil and lib.buffers[bufnr] ~= false
+end
+
 ---Public API for use in writing strategies or other custom code.
 local M = {
 	hlgroup_at = lib.hlgroup_at,
@@ -59,6 +67,7 @@ local M = {
 	enable  = enable,
 	disable = disable,
 	toggle  = toggle,
+	is_enabled  = is_enabled,
 }
 
 

--- a/test/e2e/public-api.lua
+++ b/test/e2e/public-api.lua
@@ -1,0 +1,201 @@
+local rpcrequest = vim.fn.rpcrequest
+
+local jobopts = {
+	rpc = true,
+	width = 80,
+	height = 24,
+}
+
+local exec_lua = 'nvim_exec_lua'
+local buf_set_lines = 'nvim_buf_set_lines'
+local buf_set_option = 'nvim_buf_set_option'
+local command = 'nvim_command'
+
+
+describe('The Rainbow Delimiters public API', function()
+	local nvim
+
+	local function request(method, ...)
+		return rpcrequest(nvim, method, ...)
+	end
+
+	before_each(function()
+		-- Start the remote Neovim process.  The `--embed` flag lets us control
+		-- Neovim through RPC, the `--headless` flag tells it not to wait for a
+		-- UI to attach and start loading plugins and configuration immediately
+		nvim = vim.fn.jobstart({'nvim', '--embed', '--headless'}, jobopts)
+
+		-- Set up a tracking strategy
+		request(exec_lua, [[
+			TSEnsure('markdown', 'lua', 'vim')
+			rb = require 'rainbow-delimiters'
+    		vim.g.rainbow_delimiters = {
+    			strategy = {
+    				[''] = rb.strategy.global,
+    			},
+    		}]], {})
+	end)
+
+	after_each(function()
+		vim.fn.jobstop(nvim)
+	end)
+
+	describe('Whether RB is enabled for a buffer at startup', function()
+		it('Is disabled for a buffer without file type', function()
+			assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+		end)
+
+		it('Is enabled for a supported language', function()
+			request(buf_set_option, 0, 'filetype', 'lua')
+			assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+		end)
+
+		describe('Blacklist', function()
+			before_each(function()
+				request(command, 'let g:rainbow_delimiters.blacklist = ["markdown"]')
+			end)
+
+			it('Is enabled for a not blacklisted language', function()
+				request(buf_set_option, 0, 'filetype', 'lua')
+				assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+
+			it('Is disabled for a blacklisted language', function()
+				request(buf_set_option, 0, 'filetype', 'markdown')
+				assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+
+			it('Is disabled for a blacklisted language with injected whitelisted language', function()
+				request(buf_set_lines, 0, 0, -1, true, {
+					'This is Markdown',
+					'',
+					'```lua',
+					'print(((("This is Lua"))))',
+					'```',
+					'',
+					'More Markdown',
+				})
+				request(buf_set_option, 0, 'filetype', 'markdown')
+				assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+		end)
+
+		describe('Whitelist', function()
+			before_each(function()
+				request(command, 'let g:rainbow_delimiters.whitelist = ["lua"]')
+			end)
+
+			it('Is disabled for a not whitelisted language', function()
+				request(buf_set_option, 0, 'filetype', 'markdown')
+				assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+
+			it('Is enabled for a whitelisted language', function()
+				request(buf_set_option, 0, 'filetype', 'lua')
+				assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+
+			it('Is enabled for whitelisted language with other language injected', function()
+				request(buf_set_lines, 0, 0, -1, true, {
+					'print "This is Lua"',
+					'vim.cmd [[echo "This is Vim"]]',
+				})
+				request(buf_set_option, 0, 'filetype', 'lua')
+				assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+
+			it('Is disabled for not whitelisted language with injected whitelisted language', function()
+				request(buf_set_lines, 0, 0, -1, true, {
+					'This is Markdown',
+					'',
+					'```lua',
+					'print(((("This is Lua"))))',
+					'```',
+					'',
+					'More Markdown',
+				})
+				request(buf_set_option, 0, 'filetype', 'markdown')
+				assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+		end)
+	end)
+
+	describe('Manual toggling', function()
+		it('Can be disabled for a buffer', function()
+			request(buf_set_option, 0, 'filetype', 'lua')
+			request(exec_lua, 'rb.disable(0)', {})
+			assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+		end)
+
+		it('Can be turned back on', function()
+			request(buf_set_option, 0, 'filetype', 'lua')
+			request(exec_lua, 'rb.disable(0)', {})
+			request(exec_lua, 'rb.enable(0)', {})
+			assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+		end)
+
+		it('Can be toggled off', function()
+			request(buf_set_option, 0, 'filetype', 'lua')
+			request(exec_lua, 'rb.toggle(0)', {})
+			assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+		end)
+
+		it('Can be toggled on', function()
+			request(buf_set_option, 0, 'filetype', 'lua')
+			request(exec_lua, 'rb.toggle(0)', {})
+			request(exec_lua, 'rb.toggle(0)', {})
+			assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+		end)
+
+		it('Gets disabled idempotently', function()
+			request(buf_set_option, 0, 'filetype', 'lua')
+			request(exec_lua, 'rb.disable(0)', {})
+			request(exec_lua, 'rb.disable(0)', {})
+			assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+		end)
+
+		it('Gets enabled idempotently', function()
+			request(buf_set_option, 0, 'filetype', 'lua')
+			request(exec_lua, 'rb.disable(0)', {})
+			request(exec_lua, 'rb.enable(0)', {})
+			request(exec_lua, 'rb.enable(0)', {})
+			assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+		end)
+
+		describe('Blacklist', function()
+			before_each(function()
+				request(command, 'let g:rainbow_delimiters.blacklist = ["markdown"]')
+			end)
+
+			it('Can be enabled for a blacklisted language', function()
+				request(buf_set_option, 0, 'filetype', 'markdown')
+				request(exec_lua, 'rb.enable(0)', {})
+				assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+
+			it('Can be toggled for a blacklisted language', function()
+				request(buf_set_option, 0, 'filetype', 'markdown')
+				request(exec_lua, 'rb.toggle(0)', {})
+				assert.is.True(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+		end)
+
+		describe('Whitelist', function()
+			before_each(function()
+				request(command, 'let g:rainbow_delimiters.whitelist = ["lua"]')
+			end)
+
+			it('Can be disabled for a whitelisted language', function()
+				request(buf_set_option, 0, 'filetype', 'lua')
+				request(exec_lua, 'rb.disable(0)', {})
+				assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+
+			it('Can be toggled for a whitelisted language', function()
+				request(buf_set_option, 0, 'filetype', 'lua')
+				request(exec_lua, 'rb.toggle(0)', {})
+				assert.is.False(request(exec_lua, 'return rb.is_enabled()', {}))
+			end)
+		end)
+	end)
+end)


### PR DESCRIPTION
This just adds a nice function in the API to check if rainbow delimiters are enabled in a buffer. It is currently feasible by directly requiring and accessing the internal lib functions but that seems a bit unsafe. Also was thinking if it should also check if the value isn't `nil` to see if it's actually attached. Maybe that should be a different API function (`is_attached`)? Feedback super welcome!

Also, amazing job with this project! Very much appreciate the revival of the original archived project and all of the refactors and improvements that have gotten it to where it is today :D