### PR TITLE
fix(luadoc): add new luadoc queries

### DIFF
--- a/queries/luadoc/rainbow-delimiters.scm
+++ b/queries/luadoc/rainbow-delimiters.scm
@@ -29,6 +29,16 @@
   "}" @delimiter @sentinel
 ) @container
 
+(indexed_field
+  "[" @delimiter
+  "]" @delimiter @sentinel
+) @container
+
+(tuple_type
+  "(" @delimiter
+  ")" @delimiter @sentinel
+) @container
+
 (_
   "[" @delimiter
   .

--- a/test/highlight/luadoc/regular.lua
+++ b/test/highlight/luadoc/regular.lua
@@ -8,11 +8,16 @@
 ---@field a boolean
 ---@field b (((boolean)))
 ---@field x number | string | { key: number | string | boolean } | boolean
--- This is not yet supported by the luadoc parser:
 ---@field [string] boolean
 
 ---@type string[]
 local _str_tbl = { 'a', 'b', 'c' }
+
+---@param f fun(i: integer): (integer, integer)
+---@return integer, integer
+local function _test_fun(f)
+	return f(1)
+end
 
 -- Note: The parser nests union types, which can mess
 -- with rainbow-delimiters highlighting, so we don't


### PR DESCRIPTION
The luadoc parser was updated a couple of days ago, and I found two new queries to highlight in `rainbow-delimiters`.