### PR TITLE
fix(java): delimiter not work, fix #115

### DIFF
--- a/queries/java/rainbow-delimiters.scm
+++ b/queries/java/rainbow-delimiters.scm
@@ -14,10 +14,6 @@
   "(" @delimiter
   ")" @delimiter @sentinel) @container
 
-(condition
-  "(" @delimiter
-  ")" @delimiter @sentinel) @container
-
 (resource_specification 
   "(" @delimiter
   ")" @delimiter @sentinel) @container


### PR DESCRIPTION
After some research, I find out #115 related to some treesitter deprecated syntax, and it cause a error with nvim 0.10, see this  [issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/6649).
I'm not very familiar with treesitter query syntax, but by remove the `condition` block, delimiter for java work well now