### PR TITLE
Cleanup + missing rust query + wgsl support

### DIFF
--- a/lua/rainbow-delimiters.types.lua
+++ b/lua/rainbow-delimiters.types.lua
@@ -15,7 +15,7 @@
 
 ---@class (exact) rainbow_delimiters.buffer_settings
 ---@field strategy rainbow_delimiters.strategy
----@field parser LanguageTree
+---@field parser vim.treesitter.LanguageTree
 ---@field lang string
 
 

--- a/lua/rainbow-delimiters.types.lua
+++ b/lua/rainbow-delimiters.types.lua
@@ -100,6 +100,7 @@
 ---@field vim          (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field vimdoc       (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field vue          (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
+---@field wgsl         (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field yaml         (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---@field zig          (rainbow_delimiters.strategy | fun(bufnr: integer): rainbow_delimiters.strategy?)?
 ---User defined language, not part of rainbow_delimiters support
@@ -167,6 +168,7 @@
 ---@field vim          (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field vimdoc       (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field vue          (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
+---@field wgsl         (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field yaml         (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field zig          (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---User defined language, not part of rainbow_delimiters support
@@ -234,6 +236,7 @@
 ---@field vim          (integer | fun(bufnr: integer): integer)?
 ---@field vimdoc       (integer | fun(bufnr: integer): integer)?
 ---@field vue          (integer | fun(bufnr: integer): integer)?
+---@field wgsl         (integer | fun(bufnr: integer): integer)?
 ---@field yaml         (integer | fun(bufnr: integer): integer)?
 ---@field zig          (integer | fun(bufnr: integer): integer)?
 ---User defined language, not part of rainbow_delimiters support
@@ -301,6 +304,7 @@
 ---| 'vim'
 ---| 'vimdoc'
 ---| 'vue'
+---| 'wgsl'
 ---| 'yaml'
 ---| 'zig'
 ---User defined language, not part of rainbow_delimiters support

--- a/lua/rainbow-delimiters/lib.lua
+++ b/lua/rainbow-delimiters/lib.lua
@@ -15,7 +15,6 @@
    limitations under the License.
 --]]
 
-local api        = vim.api
 local get_query  = vim.treesitter.query.get
 local get_parser = vim.treesitter.get_parser
 local log        = require 'rainbow-delimiters.log'
@@ -69,7 +68,7 @@ M.buffers = {}
 ---
 ---@param lang  string   Name of the language to get the query for
 ---@param bufnr integer  Use this buffer as the current buffer
----@return Query? query  The query object
+---@return vim.treesitter.Query? query  The query object
 function M.get_query(lang, bufnr)
 	local name = config['query'][lang]
 	if type(name) == "function" then
@@ -194,7 +193,7 @@ function M.attach(bufnr)
 			if not M.buffers[bnr] then return end
 			M.detach(bufnr)
 		end,
-		---@param child LanguageTree
+		---@param child vim.treesitter.LanguageTree
 		on_child_removed = function(child)
 			M.clear_namespace(bufnr, child:lang())
 		end,

--- a/lua/rainbow-delimiters/strategy/global.lua
+++ b/lua/rainbow-delimiters/strategy/global.lua
@@ -165,7 +165,7 @@ end
 
 ---Update highlights for every tree in given buffer.
 ---@param bufnr integer # Buffer number
----@param parser LanguageTree
+---@param parser vim.treesitter.LanguageTree
 local function full_update(bufnr, parser)
 	log.debug('Performing full updated on buffer %d', bufnr)
 	local function callback(tree, sub_parser)
@@ -179,7 +179,7 @@ end
 
 ---Sets up all the callbacks and performs an initial highlighting
 ---@param bufnr integer # Buffer number
----@param parser LanguageTree
+---@param parser vim.treesitter.LanguageTree
 ---@param start_parent_lang string? # Parent language or nil
 local function setup_parser(bufnr, parser, start_parent_lang)
 	log.debug('Setting up parser for buffer %d', bufnr)
@@ -261,7 +261,7 @@ local function setup_parser(bufnr, parser, start_parent_lang)
 			end,
 			-- New languages can be added into the text at some later time, e.g.
 			-- code snippets in Markdown
-			---@param child LanguageTree
+			---@param child vim.treesitter.LanguageTree
 			on_child_added = function(child)
 				setup_parser(bufnr, child, lang)
 			end,

--- a/lua/rainbow-delimiters/strategy/local.lua
+++ b/lua/rainbow-delimiters/strategy/local.lua
@@ -235,7 +235,7 @@ end
 ---Callback function to re-highlight the buffer according to the current cursor
 ---position.
 ---@param bufnr integer
----@param parser LanguageTree
+---@param parser vim.treesitter.LanguageTree
 local function local_rainbow(bufnr, parser)
 	parser:for_each_tree(function(tree, sub_parser)
 		update_local(bufnr, tree, sub_parser:lang())
@@ -244,7 +244,7 @@ end
 
 ---Sets up all the callbacks and performs an initial highlighting
 ---@param bufnr integer # Buffer number
----@param parser LanguageTree
+---@param parser vim.treesitter.LanguageTree
 local function setup_parser(bufnr, parser)
 	log.debug('Setting up parser for buffer %d', bufnr)
 	util.for_each_child(nil, parser:lang(), parser, function(p, lang, _parent_lang)
@@ -274,7 +274,7 @@ local function setup_parser(bufnr, parser)
 			end,
 			-- New languages can be added into the text at some later time, e.g.
 			-- code snippets in Markdown
-			---@param child LanguageTree
+			---@param child vim.treesitter.LanguageTree
 			on_child_added = function(child)
 				setup_parser(bufnr, child)
 			end,

--- a/lua/rainbow-delimiters/util.lua
+++ b/lua/rainbow-delimiters/util.lua
@@ -27,8 +27,8 @@ local M = {}
 ---replacement.
 ---@param parent_lang string? # Parent language or nil
 ---@param lang string
----@param language_tree LanguageTree
----@param thunk fun(p: LanguageTree, lang: string, parent_lang: string?)
+---@param language_tree vim.treesitter.LanguageTree
+---@param thunk fun(p: vim.treesitter.LanguageTree, lang: string, parent_lang: string?)
 function M.for_each_child(parent_lang, lang, language_tree, thunk)
 	thunk(language_tree, lang, parent_lang)
 	local children = language_tree:children()

--- a/queries/rust/rainbow-delimiters.scm
+++ b/queries/rust/rainbow-delimiters.scm
@@ -131,3 +131,7 @@
 (visibility_modifier
   "(" @delimiter
   ")" @delimiter @sentinel) @container
+
+(bracketed_type
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container

--- a/queries/wgsl/rainbow-delimiters.scm
+++ b/queries/wgsl/rainbow-delimiters.scm
@@ -1,0 +1,47 @@
+(argument_list_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(attribute
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(compound_statement
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(function_declaration
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(for_statement
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(loop_statement
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(parenthesized_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(postfix_expression
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(struct_declaration
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(subscript_expression
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(type_declaration
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
+
+(variable_qualifier
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container

--- a/test/highlight/rust/regular.rs
+++ b/test/highlight/rust/regular.rs
@@ -130,6 +130,8 @@ fn main() {
 
     let test_tuple: (u32, u32) = (0, 1);
     tuple_param(test_tuple);
+
+    let a = <u32 as From<u8>>::from(1u8);
 }
 
 use level_1::{

--- a/test/highlight/wgsl/regular.wgsl
+++ b/test/highlight/wgsl/regular.wgsl
@@ -1,0 +1,57 @@
+@group(0)
+@binding(0)
+var<storage, read> array_1: array<u32, 10>;
+
+@group(0)
+@binding(1)
+var<uniform> array_2: array<vec4<u32>, 256>;
+
+@group(1)
+@binding(0)
+var<storage, read_write> array_3: array<vec2<f32>, 100>;
+
+struct MyStruct {
+    x: f32,
+    y: f32,
+    i: u32,
+    j: u32,
+}
+
+fn next_bit_string_same_hamming_weight(bit_string: u32) -> u32 {
+    let t = bit_string | (bit_string - 1u); // bit_string with least significant 0 set to 1
+    let tmp = (~t & (0u - ~t)) - 1u;
+    return (t+1) | (tmp >> (countTrailingZeros(bit_string) + 1u));
+}
+
+fn function_with_loop(a: u32, b_ptr: ptr<function, u32>) {
+    var bits = a;
+    loop {
+        if (bits & 3u) == 0u {
+            return;
+        } else {
+            bits = bits - 1u;
+            *b_ptr += 1u;
+        }
+    }
+}
+
+@compute
+@workgroup_size(32)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+) {
+    let start = 10 * global_id.x;
+
+    if (global_id.x >= 10) { return; }
+    var a = array_1[global_id.x];
+
+    let end = start + 10;
+
+    for (var id = start; id < end; id += 1u) {
+        if (id >= 100) { return; }
+
+        var b = array_3[id].x;
+
+        array_3[id].y = a + b;
+    }
+}


### PR DESCRIPTION
Neovim has updated some type signatures, so I updated them too here. 

Also `regtype = 'c'` causes errors for me, so I changed it to `regtype = 'v'`, which seems to be what we want -- see: https://neovim.io/doc/user/builtin.html#getregtype() . I am not sure when this was changed in Neovim recently, or if this code has always been wrong? (Wrong in the sense that it maybe should have been `'v'` technically, although it definitely did accept `'c'` previously.)

(Note: I haven't yet tested this in older versions of Neovim)

Finally I added a missing rust query and wgsl support in separate commits. 