### PR TITLE
Add missing rust query

### DIFF
--- a/queries/rust/rainbow-delimiters.scm
+++ b/queries/rust/rainbow-delimiters.scm
@@ -62,6 +62,10 @@
   "[" @delimiter
   "]" @delimiter @sentinel) @container
 
+(token_tree
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
+
 (token_tree_pattern
   "(" @delimiter
   ")" @delimiter @sentinel) @container

--- a/test/highlight/rust/regular.rs
+++ b/test/highlight/rust/regular.rs
@@ -17,6 +17,16 @@ union TestUnion {
     val_2: u32,
 }
 
+struct Generic<T> {
+    t: T,
+}
+
+impl<T> Generic<T> {
+    fn new(t: T) -> Generic<T> {
+        Generic { t }
+    }
+}
+
 #[derive(Default, Debug)]
 struct TupleStruct(u32);
 
@@ -131,7 +141,10 @@ fn main() {
     let test_tuple: (u32, u32) = (0, 1);
     tuple_param(test_tuple);
 
-    let a = <u32 as From<u8>>::from(1u8);
+    let bracketed_type = <u32 as From<u8>>::from(1u8);
+
+    let generic = Generic::<u8>::new(1);
+    let generic_in_macro = vec![Generic::<u8>::new(1)];
 }
 
 use level_1::{


### PR DESCRIPTION
Note that the current neovim treesitter implementation only captures anything inside a rust macro via token_tree, so we need this new query to capture <T>.

I added some examples in the test file, but the only thing the new query fixes is the line with:
```rust
vec![Generic::<u8>::new(1)]
```

I only just now figured out that we don't actually capture the stuff inside macros via the standard queries, we only capture things inside e.g. a `vec!` via `token_tree`. 

Knowing this might help fixing the highlighting in C/C++ too (see #80) - I will try to fix that as well. 