### PR TITLE
`global` strategy rewrite (draft)

### DIFF
--- a/lua/rainbow-delimiters.lua
+++ b/lua/rainbow-delimiters.lua
@@ -63,6 +63,7 @@ local M = {
 		['local']  = require 'rainbow-delimiters.strategy.local',
 		---Empty highlighting strategy for testing
 		['noop']   = require 'rainbow-delimiters.strategy.no-op',
+		['window'] = require 'rainbow-delimiters.strategy.window',
 	},
 	enable  = enable,
 	disable = disable,

--- a/lua/rainbow-delimiters/strategy/global.lua
+++ b/lua/rainbow-delimiters/strategy/global.lua
@@ -156,7 +156,6 @@ local function update_range(bufnr, changes, tree, lang)
 				local match_sentinel_row, match_sentinel_col = match_sentinel[1], match_sentinel[2]
 				local other_sentinel = other.sentinel ---@type integer[]
 				local other_sentinel_row, other_sentinel_col = other_sentinel[1], other_sentinel[2]
-
 				if
 					(match_start_row < other_start_row
 						or (match_start_row == other_start_row and match_start_col <= other_start_col))
@@ -229,14 +228,13 @@ local function setup_parser(bufnr, parser, start_parent_lang)
 
 				-- maybe change self_injecting_languages to { rust = true },
 				-- since that seems to be the main different one
-				local self_injecting_languages = { c = true, cpp = true, markdown = true, }
 				if not parent_lang then
 					-- If we have no parent language, then we use changes, otherwise we use the
 					-- whole tree's range.
 					-- Normalize the changes object if we have no parent language (the one we
 					-- get from on_changedtree)
 					changes = vim.tbl_map(normalize_change, changes)
-				elseif parent_lang ~= lang or self_injecting_languages[parent_lang] then
+				elseif parent_lang ~= lang or lang ~= 'rust' then
 					-- We have a parent language, so we are in an injected language code
 					-- block, thus we update all of the current code block.
 					changes = {{tree:root():range()}}

--- a/lua/rainbow-delimiters/strategy/global.lua
+++ b/lua/rainbow-delimiters/strategy/global.lua
@@ -19,6 +19,7 @@ local Stack = require 'rainbow-delimiters.stack'
 local lib   = require 'rainbow-delimiters.lib'
 local util  = require 'rainbow-delimiters.util'
 local log   = require 'rainbow-delimiters.log'
+local ts    = vim.treesitter
 
 
 ---Strategy which highlights the entire buffer.
@@ -34,7 +35,7 @@ local function normalize_change(change)
 	if #change == 4 then
 		result = change
 	elseif #change == 6 then
-		result = {change[1], change[2], change[4], change[5]}
+		result = { change[1], change[2], change[4], change[5] }
 	else
 		result = {}
 	end
@@ -51,16 +52,6 @@ local function highlight_matches(bufnr, lang, matches, level)
 		for _, delimiter in match.delimiter:iter() do lib.highlight(bufnr, lang, delimiter, hlgroup) end
 		highlight_matches(bufnr, lang, match.children, level + 1)
 	end
-end
-
-
----Create a new empty match_record
----@return table
-local function new_match_record()
-	return {
-		delimiter = Stack.new(),
-		children = Stack.new(),
-	}
 end
 
 ---Update highlights for a range. Called every time text is changed.
@@ -80,85 +71,65 @@ local function update_range(bufnr, changes, tree, lang)
 	local matches = Stack.new()
 
 	for _, change in ipairs(changes) do
-		-- This is the match record, it lists all the relevant nodes from
-		-- each match.
-		---@type table?
-		local match_record
 		local root_node = tree:root()
 		local start_row, end_row = change[1], change[3] + 1
 		lib.clear_namespace(bufnr, lang, start_row, end_row)
 
-		for qid, node, _ in query:iter_captures(root_node, bufnr, start_row, end_row) do
-			local name = query.captures[qid]
-			-- check for 'delimiter' first, since that should be the most
-			-- common name
-			if name == 'delimiter' and match_record then
-				match_record.delimiter:push(node)
-			elseif name == 'container' and not match_record then
-				match_record = new_match_record()
-			elseif name == 'container' then
-				-- temporarily push the match_record to matches to be retrieved
-				-- later, since we haven't closed it yet
-				matches:push(match_record)
-				match_record = new_match_record()
-				-- since we didn't close the previous match_record, it must
-				-- mean that the current match_record has it as an ancestor
-				match_record.has_ancestor = true
-			elseif name == 'sentinel' and match_record then
-				-- if we see the sentinel, then we are done with the current
-				-- container
-				if match_record.has_ancestor then
-					local prev_match_record = matches:pop()
-					if prev_match_record then
-						-- since we have an ancestor, it has to be the last
-						-- element of the stack
-						prev_match_record.children:push(match_record)
-						match_record = prev_match_record
-					else
-						-- since match_record.has_ancestor was true, we shouldn't
-						-- be able to get to here unless something went wrong
-						-- with the queries or treesitter itself
-						log.error([[You are missing a @container,
-									which should be impossible!
-									Please double check the queries.]])
+		for _pattern, match, _metadata in query:iter_matches(root_node, bufnr, start_row, end_row, { all = true }) do
+			-- This is the match record, it lists all the relevant nodes from
+			-- each match. We start with the root_node as the container, but
+			-- we will update this later.
+			local match_record = {
+				container = root_node,
+				delimiter = Stack.new(),
+				children = Stack.new(),
+				sentinel = nil, ---@type integer[]?
+			}
+			for id, nodes in pairs(match) do
+				local name = query.captures[id]
+				for _, node in ipairs(nodes) do
+					-- check for 'delimiter' first, since that should be the most
+					-- common name
+					if name == 'delimiter' then
+						match_record.delimiter:push(node)
+					elseif name == 'container' then
+						-- we update the container here
+						match_record.container = node
+					elseif name == 'sentinel' then
+						-- if a sentinel is given, we save the position here
+						local sentinel_row, sentinel_col, _ = node:end_()
+						match_record.sentinel = { sentinel_row, sentinel_col }
+					end
+				end
+			end
+
+			-- if sentinel_row is not nil, then sentinel_col is also
+			-- not nil
+			for _, other in matches:iter() do
+				local sentinel = other.sentinel ---@type integer[]?
+				if sentinel then
+					local this_row, this_col, _ = match_record.container:start()
+					local sentinel_row, sentinel_col = sentinel[1], sentinel[2]
+					if this_row > sentinel_row or (this_row == sentinel_row and this_col > sentinel_col) then
+						-- if other starts after the sentinel, then it should
+						-- not be included with the children of the current
+						-- match_record
+						break
 					end
 				else
-					-- if match_record doesn't have an ancestor, the sentinel
-					-- means that we are done with it
-					matches:push(match_record)
-					match_record = nil
+					if not ts.is_ancestor(match_record.container, other.container) then
+						-- if other is not in the match_record container, then it
+						-- should not be included with the children of the current
+						-- match_record
+						break
+					end
 				end
-			elseif (name == 'delimiter' or name == 'sentinel') and not match_record then
-				log.error([[You query got the capture name %s.
-					But it didn't come with a container, which should be impossible!
-						Please double check your queries.]], name)
-			end -- do nothing with other capture names
-		end
-		if match_record then
-			-- we might have a dangling match_record, so we push it back into
-			-- matches
-			-- this should only happen when the query is on a proper subset
-			-- of the full tree (usually just one line)
+				match_record.children:push(other)
+				matches:pop()
+			end
 			matches:push(match_record)
 		end
 	end
-
-	-- when we capture on a row and not the full tree, we get the previous
-	-- containers (on earlier rows) included in the above, but not the
-	-- delimiters and sentinels from them, so we push them up as long as
-	-- we know they have an ancestor
-	local last_match = matches:pop()
-	while last_match and last_match.has_ancestor do
-		local prev_match = matches:pop()
-
-		if prev_match then
-			prev_match.children:push(last_match)
-		else
-			log.error('You are in what should be an unreachable position.')
-		end
-		last_match = prev_match
-	end
-	matches:push(last_match)
 
 	highlight_matches(bufnr, lang, matches, 1)
 end
@@ -201,21 +172,27 @@ local function setup_parser(bufnr, parser, start_parent_lang)
 
 				-- HACK: changes can accidentally overwrite highlighting in injected code
 				-- blocks.
+
+				-- maybe change self_injecting_languages to { rust = true },
+				-- since that seems to be the main different one
+				local self_injecting_languages = { c = true, cpp = true, markdown = true, }
 				if not parent_lang then
 					-- If we have no parent language, then we use changes, otherwise we use the
 					-- whole tree's range.
 					-- Normalize the changes object if we have no parent language (the one we
 					-- get from on_changedtree)
 					changes = vim.tbl_map(normalize_change, changes)
-				elseif parent_lang ~= lang and changes[1] then
+				elseif parent_lang ~= lang or self_injecting_languages[parent_lang] then
 					-- We have a parent language, so we are in an injected language code
-					-- block, thus we update all of the current code block
+					-- block, thus we update all of the current code block.
 					changes = {{tree:root():range()}}
 				else
-					-- some languages (like rust) use injections of the language itself for
+					-- Some languages (like rust) use injections of the language itself for
 					-- certain functionality (e.g., macros in rust).  For these the
 					-- highlighting will be updated by the non-injected language part of the
-					-- code.
+					-- code. Note that some self_injecting_languages don't
+					-- highlight the injected part this way, so they are
+					-- covered above.
 					changes = {}
 				end
 

--- a/lua/rainbow-delimiters/strategy/window.lua
+++ b/lua/rainbow-delimiters/strategy/window.lua
@@ -1,0 +1,231 @@
+local Stack        = require 'rainbow-delimiters.stack'
+local config       = require 'rainbow-delimiters.config'
+local lib          = require 'rainbow-delimiters.lib'
+local log          = require 'rainbow-delimiters.log'
+local util         = require 'rainbow-delimiters.util'
+local api          = vim.api
+local ts           = vim.treesitter
+local set_provider = api.nvim_set_decoration_provider
+local set_extmark  = api.nvim_buf_set_extmark
+
+
+---Strategy which highlights the entire buffer.
+local M = {}
+
+M.nsid = api.nvim_create_namespace('RainbowDelimiterWindow')
+
+
+---@param bufnr integer
+---@param nsid integer
+---@param matches Stack
+---@param level integer
+---@param hlgroups string[]
+local function highlight_matches(bufnr, nsid, priority, matches, level, hlgroups)
+	local hlgroup = hlgroups[(level - 1) % #hlgroups + 1]
+	for _, match in matches:iter() do
+		for _, delimiter in match.delimiter:iter() do
+			local start_row, start_col, end_row, end_col = delimiter:range(false)
+			set_extmark(bufnr, nsid, start_row, start_col, {
+				end_row = end_row,
+				end_col = end_col,
+				hl_group = hlgroup,
+				strict = false,
+				ephemeral = true,
+			})
+		end
+		highlight_matches(bufnr, nsid, priority, match.children, level + 1, hlgroups)
+	end
+end
+
+---@param child table
+---@param parent Stack
+local function put_child_into_parent(child, parent)
+	local child_range = child.container
+	local child_start_row, child_start_col = child_range[1], child_range[2]
+	local child_sentinel = child.sentinel
+	local child_sentinel_row, child_sentinel_col = child_sentinel[1], child_sentinel[2]
+
+	for _, current_child in parent:iter() do
+		local cur_child_range = current_child.container
+		local cur_start_row, cur_start_col = cur_child_range[1], cur_child_range[2]
+		local cur_sentinel = current_child.sentinel
+		local cur_sentinel_row, cur_sentinel_col = cur_sentinel[1], cur_sentinel[2]
+
+		if
+			(cur_start_row < child_start_row
+				or (cur_start_row == child_start_row and cur_start_col <= child_start_col))
+			and
+			(child_sentinel_row < cur_sentinel_row
+				or (child_sentinel_row == cur_sentinel_row and child_sentinel_col <= cur_sentinel_col))
+		then
+			put_child_into_parent(child, current_child.children)
+			return
+		elseif
+			(child_start_row < cur_start_row
+				or (child_start_row == cur_start_row and child_start_col <= cur_start_col))
+			and
+			(cur_sentinel_row < child_sentinel_row
+				or (cur_sentinel_row == child_sentinel_row and cur_sentinel_col <= child_sentinel_col))
+		then
+			put_child_into_parent(current_child, child.children)
+			parent:pop()
+		else
+			break
+		end
+	end
+
+	parent:push(child)
+end
+
+---Update highlights for a range. Called every time text is changed.
+---@param bufnr   integer  Buffer number
+---@param toprow  integer Top row of the window
+---@param botrow  integer Bottom row of the window
+---@param tree    TSTree  TS tree
+---@param lang    string  Language
+---@param hlgroups string[]
+local function update_range(bufnr, toprow, botrow, tree, lang, hlgroups)
+	log.debug('Updated range with changes %s', vim.inspect({toprow, botrow}))
+
+	if not lib.enabled_for(lang) then return end
+	if vim.fn.pumvisible() ~= 0 or not lang then return end
+
+	local query = lib.get_query(lang, bufnr)
+	if not query then return end
+
+	local matches = Stack.new()
+
+	local root_node = tree:root()
+	local start_row, end_row = toprow, botrow + 1
+
+	for _pattern, match, _metadata in query:iter_matches(root_node, bufnr, start_row, end_row, { all = true }) do
+		-- This is the match record, it lists all the relevant nodes from
+		-- each match. We start with the root_node as the container, but
+		-- we will update this later.
+		local match_record = {
+			container = {root_node:range()},
+			delimiter = Stack.new(),
+			children = Stack.new(),
+			sentinel = nil, ---@type integer[]?
+		}
+		for id, nodes in pairs(match) do
+			local name = query.captures[id]
+			for _, node in ipairs(nodes) do
+				-- check for 'delimiter' first, since that should be the most
+				-- common name
+				if name == 'delimiter' then
+					match_record.delimiter:push(node)
+				elseif name == 'container' then
+					-- we update the container here
+					match_record.container = {node:range()}
+				elseif name == 'sentinel' then
+					-- if a sentinel is given, we save the position here
+					local sentinel_row, sentinel_col, _ = node:end_()
+					match_record.sentinel = { sentinel_row, sentinel_col }
+				end
+			end
+		end
+		if match_record.sentinel == nil then
+			match_record.sentinel  = { match_record.container[3], match_record.container[4] }
+		end
+
+		for _, other in matches:iter() do
+			local match_range = match_record.container
+			local other_range = other.container
+			local match_start_row, match_start_col = match_range[1], match_range[2]
+			local other_start_row, other_start_col = other_range[1], other_range[2]
+
+			local match_sentinel = match_record.sentinel ---@type integer[]
+			local match_sentinel_row, match_sentinel_col = match_sentinel[1], match_sentinel[2]
+			local other_sentinel = other.sentinel ---@type integer[]
+			local other_sentinel_row, other_sentinel_col = other_sentinel[1], other_sentinel[2]
+
+			if
+				(match_start_row < other_start_row
+					or (match_start_row == other_start_row and match_start_col <= other_start_col))
+				and
+				(other_sentinel_row < match_sentinel_row
+					or (other_sentinel_row == match_sentinel_row and other_sentinel_col <= match_sentinel_col))
+			then
+				put_child_into_parent(other, match_record.children)
+				matches:pop()
+			elseif
+				(other_start_row < match_start_row
+					or (other_start_row == match_start_row and other_start_col <= match_start_col))
+				and
+				(match_sentinel_row < other_sentinel_row
+					or (match_sentinel_row == other_sentinel_row and match_sentinel_col <= other_sentinel_col))
+			then
+				local child = match_record
+				match_record = other
+				put_child_into_parent(child, match_record.children)
+				matches:pop()
+			else
+				break
+			end
+		end
+		matches:push(match_record)
+	end
+
+	local priority = config.priority[lang]
+	if type(priority) == "function" then
+		priority = priority(bufnr)
+	end
+	local nsid = M.nsid
+	highlight_matches(bufnr, nsid, priority, matches, 1, hlgroups)
+end
+
+local function on_buf(_, bufnr, _tick)
+	if bufnr ~= api.nvim_get_current_buf() or not lib.buffers[bufnr] then return false end
+end
+
+local function on_win(_, _winid, bufnr, toprow, botrow)
+	local parser_ok, parser = pcall(ts.get_parser, bufnr)
+	if not parser_ok or not parser then return false end
+
+	local hlgroups = config.highlight
+	local parent_lang = parser:lang()
+	local lang
+	local tree_start_row, tree_end_row
+	parser:for_each_tree(function(tree, sub_parser)
+		lang = sub_parser:lang()
+		if lang == parent_lang and lang == 'rust' then
+			-- for rust only highlight with the root parser
+			if sub_parser == parser then
+				tree_start_row, _, tree_end_row, _ = tree:root():range(false)
+				if tree_start_row <= botrow and tree_end_row >= toprow then
+					update_range(bufnr, toprow, botrow, tree, lang, hlgroups)
+				end
+			end
+		else
+			tree_start_row, _, tree_end_row, _ = tree:root():range(false)
+			if tree_start_row <= botrow and tree_end_row >= toprow then
+				update_range(bufnr, toprow, botrow, tree, lang, hlgroups)
+			end
+		end
+	end)
+end
+
+---on_attach implementation for the global strategy
+---@param _bufnr integer
+---@param _settings rainbow_delimiters.buffer_settings
+function M.on_attach(_bufnr, _settings)
+	log.trace('window strategy on_attach')
+	set_provider(M.nsid, { on_buf = on_buf, on_win = on_win })
+end
+
+---on_detach implementation for the global strategy
+---@param _bufnr integer
+function M.on_detach(_bufnr)
+end
+
+---on_reset implementation for the global strategy
+---@param _bufnr integer
+---@param _settings rainbow_delimiters.buffer_settings
+function M.on_reset(_bufnr, _settings)
+	log.trace('window strategy on_reset')
+end
+
+return M --[[@as rainbow_delimiters.strategy]]
+
+-- vim:tw=79:ts=4:sw=4:noet:

--- a/queries/lua/rainbow-blocks.scm
+++ b/queries/lua/rainbow-blocks.scm
@@ -42,7 +42,7 @@
   "end" @delimiter @sentinel) @container
 
 
-;;; Copied over from rainbow-parens
+;;; Copied over from rainbow-delimiters
 
 (arguments
   "(" @delimiter

--- a/queries/python/rainbow-blocks.scm
+++ b/queries/python/rainbow-blocks.scm
@@ -1,7 +1,7 @@
 ; Block specific
 (function_definition
   "def" @delimiter
-  "->" @delimiter
+  "->"? @delimiter
   ":" @delimiter) @container
 
 (for_statement

--- a/queries/python/rainbow-blocks.scm
+++ b/queries/python/rainbow-blocks.scm
@@ -1,0 +1,149 @@
+; Block specific
+(function_definition
+  "def" @delimiter
+  "->" @delimiter
+  ":" @delimiter) @container
+
+(for_statement
+  "for" @delimiter
+  "in" @delimiter
+  ":" @delimiter
+  (else_clause
+    "else" @delimiter
+    ":" @delimiter)?
+) @container
+
+(for_in_clause
+  "for" @delimiter
+  "in" @delimiter) @container
+
+(if_clause
+  "if" @delimiter) @container
+
+(conditional_expression
+  "if" @delimiter
+  "else" @delimiter) @container
+
+(if_statement
+  "if" @delimiter
+  ":" @delimiter
+  (elif_clause
+    "elif" @delimiter
+    ":" @delimiter)*
+  (else_clause
+    "else" @delimiter
+    ":" @delimiter)?
+  ) @container
+
+(match_statement
+  "match" @delimiter
+  ":" @delimiter) @container
+
+(case_clause
+  "case" @delimiter
+  ":" @delimiter) @container
+
+(lambda
+  "lambda" @delimiter
+  ":" @delimiter) @container
+
+(while_statement
+  "while" @delimiter
+  ":" @delimiter
+  (else_clause
+    "else" @delimiter
+    ":" @delimiter)?
+) @container
+
+(try_statement
+  "try" @delimiter
+  ":" @delimiter
+  (except_clause
+    "except" @delimiter
+    ":" @delimiter)*
+  (else_clause
+    "else" @delimiter
+    ":" @delimiter)?
+  (finally_clause
+    "finally" @delimiter
+    ":" @delimiter)?
+) @container
+
+(class_definition
+  "class" @delimiter
+  ":" @delimiter) @container
+
+
+; Copied over from rainbow-delimiters
+(list
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(list_pattern
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(list_comprehension
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(dictionary
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(dict_pattern
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(dictionary_comprehension
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(set
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(set_comprehension
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(tuple
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(tuple_pattern
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(generator_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(parameters
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(argument_list
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(parenthesized_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(subscript
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(type_parameter
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(import_from_statement
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(string
+  (interpolation
+    "{" @delimiter
+    "}" @delimiter @sentinel) @container)

--- a/test/highlight/python/regular.py
+++ b/test/highlight/python/regular.py
@@ -9,9 +9,24 @@ from typing import (
 
 def sum_list(lst: List[Dict[int, int]]) -> int:
     result = 0
+    tmp = {'a': (1-2), 'b': (2+1), 'c': { 'd': 1 }, 'e': { 'f': 2 }}
+    assert tmp['a'] == -1
+    if tmp['a']:
+        pass
+    if tmp['b'] == 3:
+        print('good')
+    elif tmp['a'] == tmp['b']:
+        print('error')
+    elif tmp['a'] == tmp['b'] + 1:
+        print('error')
+    else:
+        print('bad')
     for inner in lst:
         for i in inner:
             result += i
+    while True:
+        if True:
+            break
     return result
 
 
@@ -19,6 +34,10 @@ my_list = [[['Hello, world!']]]
 my_dict = {'x': {'x': {'x': 'Hello, wold!'}}}
 my_set = {{{{'Hello, wold!'}}}}
 my_tuple = (((('Hello, wold!'),),),)
+my_if_else = 1 if True else 0
+one, two = 1, 2
+my_f_str = (f"one = {one}, two = {two}")
+my_lambda = lambda x: x*x
 
 list_comp = [i for i in [j for j in range(5)] if i % 2 == 0]
 dict_comp = {k: v for k, v in {k: v for k, v in {'k': 'v'}.items()}
@@ -34,12 +53,40 @@ match my_dict:
     case (((message))):
         print(message)
 
+while False:
+    pass
+else:
+    print("while else")
+
+for i in range(1):
+    pass
+else:
+    print("for else")
+
+try:
+    print('try')
+except NameError:
+    print('except with err')
+except:
+    print('except')
+else:
+    print('no exception')
+finally:
+    print('more code')
+
+
 zero = [0]
 
 (a,b) = (1,2)
 [c,d] = [3,4]
 
 print(zero[zero[zero[0]]])
+
+class A:
+    def __init__(self) -> None: ...
+
+class B(A):
+    ...
 
 
 print(2 + ((((3)))))

--- a/test/highlight/python/regular.py
+++ b/test/highlight/python/regular.py
@@ -44,6 +44,7 @@ dict_comp = {k: v for k, v in {k: v for k, v in {'k': 'v'}.items()}
              if k == 'k'}
 set_comp = {i for i in {j for j in range(5)} if i % 2 == 0}
 gen_comp = (i for i in (j for j in range(5)) if i % 2 == 0)
+tuple_in_list_comp = [(i,j) for i in range(5) for j in range(5)]
 
 match my_dict:
     case {'x': {'x': {'x': message}}}:


### PR DESCRIPTION
Since we wanted to do a rewrite to `iter_matches` anyways, I wanted to try to make it possible to write a `rainbow-blocks` query file for python with the `iter_matches` setup, but this turned out to be quite a bit harder than I thought, because `iter_matches` doesn't always give you the matches in a nice order (for what we want to do at least), but I think the current code works pretty well now. 

Do you think something like this would be too complicated? If so, I originally had a much simpler version that worked fine for the standard queries I tried it on, but it did not work at all with something like my `rainbow-blocks` python file. 

Also, I have not tried to time any of this for now, but clearly it should be slower than what we used to have. It might be an acceptable slowdown though? (I haven't noticed much difference, but I haven't checked on really large files yet.)

Some notes:
- This code uses the end of the node as sentinel if no sentinel is provided, since that was what I would want in the cases I could think of (e.g. python `rainbow-blocks`).
- I haven't cleaned up the code or added helpful comments yet. This is just my first working version with `rainbow-blocks` for python working as I would expect. 

Small update:

Although I think the code in this PR is a bit messy, I do like the resulting python block highlighting we can get with it:

<img width="582" alt="Screenshot 2024-07-01 at 23 27 40" src="https://github.com/HiPhish/rainbow-delimiters.nvim/assets/7075380/cb72a7e7-cdcb-43e8-9cf1-837b96528895">

<img width="586" alt="Screenshot 2024-07-01 at 23 28 34" src="https://github.com/HiPhish/rainbow-delimiters.nvim/assets/7075380/39022fe8-9315-4cb2-a934-652a76468117">

