### PR TITLE
fix(c_sharp): missing tuple_pattern query

### DIFF
--- a/queries/c_sharp/rainbow-delimiters.scm
+++ b/queries/c_sharp/rainbow-delimiters.scm
@@ -38,6 +38,10 @@
   "(" @delimiter
   ")" @delimiter @sentinel) @container
 
+(tuple_pattern
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
 (attribute_argument_list
   "(" @delimiter
   ")" @delimiter @sentinel) @container

--- a/test/highlight/samples/c_sharp/misc.cs
+++ b/test/highlight/samples/c_sharp/misc.cs
@@ -36,4 +36,14 @@ public class TestClass
     {
         return (1, 2, (3, 4));
     }
+
+    private (int, int) GetTupleValue()
+    {
+        return (1, 2);
+    }
+
+    private void TestConsumeTuple()
+    {
+        var (a, b) = GetTupleValue();
+    }
 }


### PR DESCRIPTION
Hi,

I added a capture that was missing for tuple destructuring in C#.

Let me know if anything.

Thanks again for maintaining this project!