### PR TITLE
Add missing python query `format_expression`

### DIFF
--- a/queries/python/rainbow-delimiters.scm
+++ b/queries/python/rainbow-delimiters.scm
@@ -73,3 +73,7 @@
   (interpolation
     "{" @delimiter
     "}" @delimiter @sentinel) @container)
+
+(format_expression
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container

--- a/test/highlight/samples/python/regular.py
+++ b/test/highlight/samples/python/regular.py
@@ -47,3 +47,5 @@ print(len(my_list))
 
 # Format-string with embedded delimiters
 print(f'The sum of 2 and 3 is {2 + (1 + 2)}')
+padding_length = 20
+format_expr = f"{'middle':^{padding_length}}"


### PR DESCRIPTION
I found a missing python query, so this is just a minor fix. 