### PR TITLE
Added init.lua

### DIFF
--- a/lua/rainbow-delimiters/init.lua
+++ b/lua/rainbow-delimiters/init.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+---Apply the given configuration to the rainbow-delimiter settings.  Will
+---overwrite existing settings.
+---
+---@param opts rainbow_delimiters.config  Settings, same format as `vim.g.rainbow_delimiters`
+function M.setup(opts)
+	vim.g.rainbow_delimiters = opts
+end
+
+return M
+
+-- vim:tw=79:ts=4:sw=4:noet:


### PR DESCRIPTION
Adding this file would allow users call setup `require("rainbow-delimiters").setup()` instead of 
`require("rainbow-delimiters.setup").setup()` as the first is what I've seen many plugins authors do

Another reason is so lazy.nvim users can use opts instead of config which i think is recommended by lazy.nvim