### PR TITLE
java: add query for switch expression body

### DIFF
--- a/queries/java/rainbow-delimiters.scm
+++ b/queries/java/rainbow-delimiters.scm
@@ -6,6 +6,10 @@
   "{" @delimiter
   "}" @delimiter @sentinel) @container
 
+(switch_block
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
 (array_initializer
   "{" @delimiter
   "}" @delimiter @sentinel) @container


### PR DESCRIPTION
This PR fixes Java 13's switch expressions having no highlights for their body's curly braces.   
![image](https://github.com/user-attachments/assets/e1ad3b24-22d3-49c6-b6df-4ade7c96d1a7)
