### PR TITLE
fix: calculate priority using vim.hl.priorities

### DIFF
--- a/lua/rainbow-delimiters/default.lua
+++ b/lua/rainbow-delimiters/default.lua
@@ -16,6 +16,7 @@
 
 ---Default plugin configuration.
 ---@type rainbow_delimiters.config
+local priorities = (vim.hl or vim.highlight).priorities
 local M = {
 	---Query names by file type
 	query = {
@@ -27,7 +28,7 @@ local M = {
 		[''] = require 'rainbow-delimiters.strategy.global',
 	},
 	priority = {
-		[''] = 110,
+		[''] = (priorities.treesitter + priorities.semantic_tokens) // 2
 	},
 	---Event logging settings
 	log = {


### PR DESCRIPTION
Hello! In the future, it is likely that the default treesitter highlight priority will change (see https://github.com/neovim/neovim/pull/31853), which breaks this plugin. It would be nice to calculate these using `vim.highlight.priorities` (`vim.hl.priorities` on nightly). Although I am unsure how to calculate this in the vimscript example, so some help would be appreciated :) Thanks! 