### PR TITLE
feat: add support for nushell

### DIFF
--- a/lua/rainbow-delimiters.types.lua
+++ b/lua/rainbow-delimiters.types.lua
@@ -77,6 +77,7 @@
 ---@field markdown     (string | rainbow_delimiters.strategy | fun(bufnr: integer): string | rainbow_delimiters.strategy?)?
 ---@field nim          (string | rainbow_delimiters.strategy | fun(bufnr: integer): string | rainbow_delimiters.strategy?)?
 ---@field nix          (string | rainbow_delimiters.strategy | fun(bufnr: integer): string | rainbow_delimiters.strategy?)?
+---@field nu           (string | rainbow_delimiters.strategy | fun(bufnr: integer): string | rainbow_delimiters.strategy?)?
 ---@field ocaml        (string | rainbow_delimiters.strategy | fun(bufnr: integer): string | rainbow_delimiters.strategy?)?
 ---@field odin         (string | rainbow_delimiters.strategy | fun(bufnr: integer): string | rainbow_delimiters.strategy?)?
 ---@field perl         (string | rainbow_delimiters.strategy | fun(bufnr: integer): string | rainbow_delimiters.strategy?)?
@@ -149,6 +150,7 @@
 ---@field markdown     (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field nim          (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field nix          (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
+---@field nu           (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field ocaml        (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field odin         (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
 ---@field perl         (('rainbow-delimiters' | string) | fun(bufnr: integer): ('rainbow-delimiters' | string))?
@@ -221,6 +223,7 @@
 ---@field markdown     (integer | fun(bufnr: integer): integer)?
 ---@field nim          (integer | fun(bufnr: integer): integer)?
 ---@field nix          (integer | fun(bufnr: integer): integer)?
+---@field nu           (integer | fun(bufnr: integer): integer)?
 ---@field ocaml        (integer | fun(bufnr: integer): integer)?
 ---@field odin         (integer | fun(bufnr: integer): integer)?
 ---@field perl         (integer | fun(bufnr: integer): integer)?
@@ -292,6 +295,7 @@
 ---| 'markdown'
 ---| 'nim'
 ---| 'nix'
+---| 'nu'
 ---| 'ocaml'
 ---| 'odin'
 ---| 'perl'

--- a/queries/nu/rainbow-delimiters.scm
+++ b/queries/nu/rainbow-delimiters.scm
@@ -1,0 +1,43 @@
+(flag_capsule
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(expr_interpolated
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(expr_parenthesized
+  ["(" "...("] @delimiter
+  ")" @delimiter @sentinel) @container
+
+(val_table
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(val_list
+  ["[" "...["] @delimiter
+  "]" @delimiter @sentinel) @container
+
+(block
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(ctrl_match
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(val_record
+  ["{" "...{"] @delimiter
+  "}" @delimiter @sentinel) @container
+
+(val_closure
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(collection_type
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container
+
+(list_type
+  "<" @delimiter
+  ">" @delimiter @sentinel) @container

--- a/test/highlight/samples/nu/regular.nu
+++ b/test/highlight/samples/nu/regular.nu
@@ -1,6 +1,5 @@
 def foo []: [nothing -> nothing] {
-  (1 + (2 * 3))
-  echo ...([1])
+  echo ...([1]) $"(1 + (2 * 3))"
   null
 }
 

--- a/test/highlight/samples/nu/regular.nu
+++ b/test/highlight/samples/nu/regular.nu
@@ -1,0 +1,29 @@
+def foo []: [nothing -> nothing] {
+  (1 + (2 * 3))
+  echo ...([1])
+  null
+}
+
+def bar (
+  --long (-f) # flag capsule
+) {
+  # closure
+  let c = {|foo bar| $foo + $bar }
+  # record
+  let r = {key: val key2: [1 2 3] ...{key: val}}
+  # list
+  let l = [1 2 [3] ...[1 2]]
+  # table
+  let t = [[h1 h2]; [1 2]]
+  # block
+  if true {
+    ()
+  }
+  # match
+  match true {
+    true => ()
+    _ => ()
+  }
+}
+
+let foo: record<bar: list<int>> = {bar: [1 2 3]}


### PR DESCRIPTION
Homepage of the shell language: https://www.nushell.sh

<img width="447" alt="image" src="https://github.com/user-attachments/assets/8a24f40f-8a63-4bc5-be2a-1ddc56c9669c" />

Here I intentionally overlooked some delimiters where nested structures are not allowed by the grammar.