### PR TITLE
add glsl support, fix cpp and latex rainbow-blocks

### DIFF
--- a/queries/cpp/rainbow-delimiters.scm
+++ b/queries/cpp/rainbow-delimiters.scm
@@ -24,6 +24,10 @@
   "(" @delimiter
   ")" @delimiter @sentinel) @container
 
+(for_range_loop
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
 (cast_expression
   "(" @delimiter
   ")" @delimiter @sentinel) @container
@@ -41,6 +45,10 @@
   "]" @delimiter @sentinel) @container
 
 (subscript_argument_list
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(lambda_capture_specifier
   "[" @delimiter
   "]" @delimiter @sentinel) @container
 

--- a/queries/glsl/rainbow-delimiters.scm
+++ b/queries/glsl/rainbow-delimiters.scm
@@ -1,0 +1,35 @@
+(layout_qualifiers
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(parenthesized_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(for_statement
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(argument_list
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(field_declaration_list
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(compound_statement
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(array_declarator
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(subscript_expression
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(parameter_list
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/queries/latex/rainbow-blocks.scm
+++ b/queries/latex/rainbow-blocks.scm
@@ -2,6 +2,10 @@
   "$" @delimiter
   "$" @delimiter @sentinel) @container
 
+(inline_formula
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
 (generic_environment
   (begin) @delimiter
   (end)   @delimiter @sentinel) @container
@@ -9,3 +13,23 @@
 (math_environment
   (begin) @delimiter
   (end)   @delimiter @sentinel) @container
+
+(math_delimiter
+  left_command: _ @delimiter
+  left_delimiter: _ @delimiter @sentinel
+  right_command: _ @delimiter
+  right_delimiter: _ @delimiter @sentinel) @container
+
+(curly_group
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(label_definition
+  name: (curly_group_text
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+)
+
+(curly_group_text_list
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container


### PR DESCRIPTION
I noticed that in cpp, for loop like `for(auto &a:as)a=1;` and lambda capture like `[h]` in `auto f=[h]{return h;};` have no highlight, so I fixed it. In latex, I found that under rainbow-blocks, every `{}` highlights such as `\frac{}{}` which were work well were disappear, it now is fixed, and the support of highlighting `\left` `\right` pair is added in rainbow-blocks.