### PR TITLE
Zig: Add missing queries and fix broken ones

### DIFF
--- a/queries/zig/rainbow-delimiters.scm
+++ b/queries/zig/rainbow-delimiters.scm
@@ -1,3 +1,7 @@
+(parenthesized_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
 (parameters
    "(" @delimiter
    ")" @delimiter @sentinel) @container
@@ -10,13 +14,47 @@
    "(" @delimiter
    ")" @delimiter @sentinel) @container
 
+(if_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(if_type_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
 (for_statement
    "(" @delimiter
    ")" @delimiter @sentinel) @container
 
+(for_expression
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
 (while_statement
-   "(" @delimiter
-   ")" @delimiter @sentinel) @container
+  "(" @delimiter
+  .
+  condition: (_)
+  .
+  ")" @delimiter @sentinel ;; keep the sentinel for fallback
+  (
+    ":" @delimiter
+    "(" @delimiter
+    ")" @delimiter
+  )?
+) @container
+
+(while_expression
+  "(" @delimiter
+  .
+  condition: (_)
+  .
+  ")" @delimiter @sentinel ;; keep the sentinel for fallback
+  (
+  ":" @delimiter
+  "(" @delimiter
+  ")" @delimiter
+  )?
+) @container
 
 (link_section
    "(" @delimiter
@@ -48,6 +86,9 @@
    "{" @delimiter
    "}" @delimiter @sentinel) @container
 
+(switch_case
+  "=>" @delimiter @sentinel) @container
+
 (array_type
    "[" @delimiter
    "]" @delimiter @sentinel) @container
@@ -61,8 +102,15 @@
    "]" @delimiter @sentinel) @container
 
 (pointer_type
-   "[" @delimiter
-   "]" @delimiter @sentinel) @container
+  (
+    "(" @delimiter
+    ")" @delimiter @sentinel ;; keep the sentinel for fallback
+  )?
+  (
+    "[" @delimiter
+    "]" @delimiter @sentinel ;; keep the sentinel for fallback
+  )?
+) @container
 
 (block
    "{" @delimiter
@@ -86,15 +134,37 @@
   "}" @delimiter @sentinel) @container
 
 (struct_declaration
-   "{" @delimiter
-   "}" @delimiter @sentinel) @container
-
-(enum_declaration
-   "{" @delimiter
-   "}" @delimiter @sentinel) @container
-
-(union_declaration
-  "(" @delimiter
-  ")" @delimiter
+  (
+    "(" @delimiter
+    ")" @delimiter
+  )?
   "{" @delimiter
   "}" @delimiter @sentinel) @container
+
+(enum_declaration
+  (
+    "(" @delimiter
+    ")" @delimiter
+  )?
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(union_declaration
+  (
+    "(" @delimiter
+    ")" @delimiter
+  )?
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(error_set_declaration
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(byte_alignment
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(address_space
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/test/highlight/samples/zig/regular.zig
+++ b/test/highlight/samples/zig/regular.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+if_type_expr: if (true) struct {} else struct {} = .{},
+
 const Void = struct {};
 
 const MyBool = enum {
@@ -7,13 +9,47 @@ const MyBool = enum {
     my_false,
 };
 
-const SomeUnion = union(enum) {
+const SomeUnion = union {
     top: u0,
     kek: u1,
 };
 
+const SomeTaggedUnion = union(enum) {
+    top: u0,
+    kek: u1,
+};
+
+const Tag = enum(u8) {
+    a,
+    b,
+};
+
+const byte_alignment: u8 align(8) = 100;
+fn PackedStruct() type {
+    return packed struct(u64) {
+        a: u32,
+        b: u32,
+    };
+}
+const t: bool = true;
+const aligned_ptr: *align(1:0:1) bool = &t;
+const aligned_multi_ptr: *align(1:0:1) [*]bool = &t;
+
+// Example from zig gpu code
+pub fn localInvocationId(comptime ptr: *addrspace(.input) @Vector(3, u32)) void {
+    asm volatile (
+        \\OpDecorate %ptr BuiltIn LocalInvocationId
+        :
+        : [ptr] "" (ptr),
+    );
+}
+
+const parenthesized_expression: u123 = @intCast(1 << (2 << 3));
+
+const ErrorSetDecl = error{SomeError};
+
 comptime {
-    const a: anyerror!SomeUnion = SomeUnion{.top = 0};
+    const a: ErrorSetDecl!SomeUnion = SomeUnion{ .top = 0 };
 
     const b = switch (a catch |err| err) {
         SomeUnion.top => |val| val,
@@ -30,7 +66,7 @@ pub fn main() !void {
 
     const stoqn = [_]u8{ 'k', 'o', 'l', 'e', 'v' };
 
-    std.debug.print("My last {s} is {s} and it's first letter is {s}\n", .{ "name", stoqn, [_]u8{ stoqn[0] } });
+    std.debug.print("My last {s} is {s} and it's first letter is {s}\n", .{ "name", stoqn, [_]u8{stoqn[0]} });
 
     // stdout is for the actual output of your application, for example if you
     // are implementing gzip, then only the compressed bytes should be sent to
@@ -48,26 +84,52 @@ pub fn main() !void {
         },
     }
 
+    var i: u8 = 0;
     if (false) {
         const k = undefined;
         const a = undefined;
         {
             asm volatile (""
-                : [_] "=r,m" (k)
-                : [_] "r,m" (a)
+                : [_] "=r,m" (k),
+                : [_] "r,m" (a),
                 : ""
             );
         }
     } else if (true) {
-        for ("proba", 0..) |c, i| {
+        for ("proba", 0..) |c, j| {
             _ = c;
-            _ = i;
+            _ = j;
         }
     } else {
-        while (false) {
-            // ...
-        }
+        while (false) {}
+        while (false) : ({
+            i += 1;
+            i *= 2;
+        }) {}
     }
+
+    const for_expr = for (stoqn) |ch| {
+        std.debug.print("{c}", .{ch});
+    } else {
+        return void;
+    };
+    _ = for_expr;
+
+    var while_expr = while (i < 3) : ({
+        i += 1;
+        i *= 2;
+    }) {
+        std.debug.print("{}", .{i});
+    } else {
+        return void;
+    };
+    i = 0;
+    while_expr = while (i < 3) {
+        i += 1;
+    };
+
+    const if_expr = if (i > 0) i else 0;
+    _ = if_expr;
 
     try bw.flush(); // don't forget to flush!
 }


### PR DESCRIPTION
This improves the zig queries. Note: I use multiple places that we don't need `@sentinel` anymore to make the following work, but I still added `@sentinel` to give at least some reasonable highlighting in the old system. I think it might soon make more sense to just remove all `@sentinel` cases though, writing these I really saw a lot of advantages in not needing it. 