### PR TITLE
python: Add missing `with_clause`

### DIFF
--- a/queries/python/rainbow-delimiters.scm
+++ b/queries/python/rainbow-delimiters.scm
@@ -77,3 +77,7 @@
 (format_expression
   "{" @delimiter
   "}" @delimiter @sentinel) @container
+
+(with_clause
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container

--- a/test/highlight/samples/python/regular.py
+++ b/test/highlight/samples/python/regular.py
@@ -1,11 +1,18 @@
 # NOTE: When updating this file update the Starlark test file as well if
 # applicable.
 
+from tempfile import TemporaryFile
 from typing import (
     Dict,
     List,
 )
 
+with (
+    TemporaryFile(mode="w") as f1,
+    TemporaryFile(mode="w") as f2,
+):
+    f1.write("File1")
+    f2.write("File2")
 
 def sum_list(lst: List[Dict[int, int]]) -> int:
     result = 0


### PR DESCRIPTION
Noticed that this was missing while randomly using a long with clause.