### PR TITLE
Revert "Hide Git submodules from plugin managers"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-# Hack: because most plugin managers will try to automatically download
-# submodules I have renamed the `.gitmodules` file.  Contributors will have to
-# symlink the `.submodules` file to `.gitmodules` before they can use submodule
-# commands
-/.gitmodules
-
 # Tag file created by Vim
 doc/tags
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,3 @@
-# This file would normally be named `.gitmodules`, but I have intentionally
-# renamed it to prevent Neovim plugin managers from picking up on it.  This
-# avoids the problem where the submodules would get installed for users of the
-# plugin.
-
 [submodule "test/xdg/local/share/nvim/site/pack/testing/start/nvim-treesitter"]
 	path = test/xdg/local/share/nvim/site/pack/testing/start/nvim-treesitter
 	url = https://github.com/nvim-treesitter/nvim-treesitter
@@ -18,5 +13,3 @@
 [submodule "test/bin"]
 	path = test/bin
 	url = https://gitlab.com/HiPhish/nvim-busted-shims.git
-
-# vim:ft=gitconfig

--- a/README.rst
+++ b/README.rst
@@ -117,24 +117,6 @@ There are only so many languages which I understand to the point that I can
 write queries for them.  If you want support for a new language please consider
 contributing code.  See the CONTRIBUTING_ for details.
 
-Contributing
-============
-
-TL;DR: Run these steps first if you want to run tests:
-
-.. code:: sh
-
-   ln -s .submodules .gitmodules
-   git submodule init
-   git submodule updated --checkout
-
-To provide some context, there are dependencies needed to run tests.  These are
-included as Git submodules.  The problem is that a number of package managers
-will download submodules by default, which means that users will end up with a
-bunch of stuff installed that they don't want.  There is no way to tell Git to
-use a different file, so we have to create a symbolic link instead if we
-actually do want to download these submodules.
-
 
 Status of the plugin
 ####################


### PR DESCRIPTION
Fixes https://github.com/HiPhish/rainbow-delimiters.nvim/issues/185

This PR reverts commit 49372aadaaf04d14a50efaa34150c51d5a8047e1 which introduced a regression on workflows that used this repository as a git submodule.

I understand the motivation behind the original change, but until we have a forward-compatible fix, reverting is the least risky option to restore stability for affected users.

This revert is minimal and self-contained. If you’d prefer a different direction, I’m happy to rework this PR, but I wanted to provide a quick path to unblock users.