### PR TITLE
feat: add support for jinja templates (htmljinja)

### DIFF
--- a/queries/htmljinja/rainbow-delimiters.scm
+++ b/queries/htmljinja/rainbow-delimiters.scm
@@ -1,0 +1,3 @@
+;;; Intentionally empty.  A Jinja template contains HTML, and this file exists
+;;; so that the HTML nodes can be highlighted.  This query only exists to
+;;; satisfy the requirements of this plugin.


### PR DESCRIPTION
This adds the same file for htmljinja as is included for htmldjango. There are also the jinja and jinja2 filetypes that usually include HTML, but I always just write `{# vim: set filetype=htmljinja: #}` at the top of my files since vim usually picks it up as `htmldjango` filetype otherwise.