### PR TITLE
Add Elixir "do end" block support for colouring

### DIFF
--- a/queries/elixir/rainbow-blocks.scm
+++ b/queries/elixir/rainbow-blocks.scm
@@ -1,0 +1,38 @@
+(call
+  (arguments
+    "(" @delimiter
+    ")" @delimiter @sentinel) @container)
+
+(block
+  "(" @delimiter
+  ")" @delimiter @sentinel) @container
+
+(string
+  (interpolation
+    "#{" @delimiter
+    "}" @delimiter @sentinel) @container)
+
+(tuple
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(list
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(access_call
+  "[" @delimiter
+  "]" @delimiter @sentinel) @container
+
+(bitstring
+  "<<" @delimiter
+  ">>" @delimiter @sentinel) @container
+
+(map
+  "%" @delimiter
+  "{" @delimiter
+  "}" @delimiter @sentinel) @container
+
+(do_block
+  "do" @delimiter
+  "end" @delimiter) @container

--- a/test/highlight/samples/elixir/regular.exs
+++ b/test/highlight/samples/elixir/regular.exs
@@ -28,6 +28,40 @@ defmodule Regular do
     end
 end
 
+defmodule DoEndBlocks do
+    @moduledoc """
+    Testing do end block nesting.
+    """
+
+    def check(x) do
+        if x > 0 do
+            :ok
+        else
+            :error
+        end
+    end
+
+    def nested(x) do
+        if x > 0 do
+            if x > 10 do
+                :big
+            else
+                :small
+            end
+        else
+            :negative
+        end
+    end
+
+    def try_example(x) do
+        try do
+            x + 1
+        rescue
+            _ -> :error
+        end
+    end
+end
+
 # Keyword list syntactic sugar
 IO.puts inspect([a: 1, b: [c: 3, d: [e: 5, f: []]]])
 


### PR DESCRIPTION
This adds highlighting support for Elixir "do end" blocks. I also updated the sample test file to cover nested "do end" blocks.

I found this useful locally, and I think it improves readability for nested Elixir blocks.

Since "do end" is a keyword pair rather than punctuation, I realize this may be a judgment call for what should count as a delimiter by default, but I thought it was worth proposing.