### PR TITLE
add heex queries, add queries for all elixir blocks

### DIFF
--- a/queries/elixir/rainbow-blocks.scm
+++ b/queries/elixir/rainbow-blocks.scm
@@ -36,3 +36,112 @@
 (do_block
   "do" @delimiter
   "end" @delimiter) @container
+
+(call
+  target: (identifier) @name @delimiter
+  (#any-of? @name "defmodule" "def" "defp" "defmacro" "quote")
+  (arguments)?
+  (do_block
+    "do" @delimiter
+    "end" @delimiter
+  )
+) @container
+
+(call
+ target: (identifier) @name @delimiter (#eq? @name "with")
+  (arguments
+    [(binary_operator
+      "<-" @delimiter) ("," @delimiter) _]+)
+  (do_block
+    "do" @delimiter
+    (else_block
+      "else" @delimiter
+      (stab_clause
+        "->" @delimiter
+      )*
+    )?
+    "end" @delimiter  )
+) @container
+
+(anonymous_function
+  "fn" @delimiter
+  (stab_clause
+    "->" @delimiter
+  )*
+  "end" @delimiter) @container
+
+(call
+  target: (identifier) @name @delimiter
+  (#any-of? @name "if" "unless")
+  (arguments)
+  (do_block
+    "do" @delimiter
+    (else_block
+      "else" @delimiter
+    )?
+    "end" @delimiter
+  )
+) @container
+
+(call
+  target: (identifier) @name @delimiter
+  (#any-of? @name "case" "cond")
+  (arguments)?
+  (do_block
+    "do" @delimiter
+    (stab_clause
+      "->" @delimiter
+    )*
+    "end" @delimiter
+  )
+) @container
+
+(call
+  target: (identifier) @name @delimiter (#eq? @name "for")
+  (arguments
+    [(binary_operator
+      "<-" @delimiter) _]+)
+  (do_block
+    "do" @delimiter
+    "end" @delimiter  )
+) @container
+
+(call
+  target: (identifier) @name @delimiter (#eq? @name "receive")
+  (do_block
+    "do" @delimiter
+    (stab_clause
+      "->" @delimiter
+    )*
+    (after_block
+      "after" @delimiter
+      (stab_clause
+        "->" @delimiter
+      )*
+    )?
+    "end" @delimiter  )
+) @container
+
+(call
+  target: (identifier) @name @delimiter (#eq? @name "try")
+  (do_block
+    "do" @delimiter
+    (rescue_block
+      "rescue" @delimiter
+      (stab_clause
+        "->" @delimiter
+      )*
+    )?
+    (catch_block
+      "catch" @delimiter
+      (stab_clause
+        "->" @delimiter
+      )*
+    )?
+    (after_block
+      "after" @delimiter
+    )?
+    "end" @delimiter  )
+) @container
+
+

--- a/queries/heex/rainbow-delimiters.scm
+++ b/queries/heex/rainbow-delimiters.scm
@@ -1,0 +1,42 @@
+(tag
+  (start_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)
+  (end_tag
+    "</" @delimiter
+    (tag_name) @delimiter
+    ">" @delimiter)) @container
+
+(tag
+  (self_closing_tag
+    "<" @delimiter
+    (tag_name) @delimiter
+    "/>" @delimiter)) @container
+
+(component
+  (start_component
+    "<" @delimiter
+    (component_name) @delimiter
+    ">" @delimiter)
+  (end_component
+    "</" @delimiter
+    (component_name) @delimiter
+    ">" @delimiter)) @container
+
+(component
+  (self_closing_component
+    "<" @delimiter
+    (component_name) @delimiter
+    "/>" @delimiter)) @container
+
+(slot
+  (start_slot
+    "<:" @delimiter
+    (slot_name) @delimiter
+    ">" @delimiter)
+  (end_slot
+    "</:" @delimiter
+    (slot_name) @delimiter
+    ">" @delimiter)) @container
+

--- a/test/highlight/samples/elixir/regular.exs
+++ b/test/highlight/samples/elixir/regular.exs
@@ -1,69 +1,186 @@
 defmodule Regular do
-    @moduledoc """
-    A dummy test module.
-    """
+  @moduledoc """
+  A dummy test module.
+  """
 
-    def first_plus_five([head | tail]) do
-        IO.puts "The first value is #{head}"
-        head + (((1 + (2 + 3))))
-    end
+  def first_plus_five([head | tail]) do
+    IO.puts("The first value is #{head}")
+    head + (1 + (2 + 3))
+  end
 
-    def first_plus_five({a, b}) do
-        IO.puts "The first value is #{a}"
-        a + (((1 + (2 + 3))))
-    end
+  def first_plus_five({a, b}) do
+    IO.puts("The first value is #{a}")
+    a + (1 + (2 + 3))
+  end
 
-    def first_plus_five(<<r, g, b>>) do
-        IO.puts "The first value is #{r}"
-        r + (((1 + (2 + 3))))
-    end
+  def first_plus_five(<<r, g, b>>) do
+    IO.puts("The first value is #{r}")
+    r + (1 + (2 + 3))
+  end
 
-    def first_plus_five(%{head => _}) do
-        IO.puts "The first value is #{head}"
-        head + (((1 + (2 + 3))))
-    end
+  def first_plus_five(%{head => _}) do
+    IO.puts("The first value is #{head}")
+    head + (1 + (2 + 3))
+  end
 
-    defp accessLookup(map, x) do
-        map[map[map[map[x]]]]
-    end
-end
-
-defmodule DoEndBlocks do
-    @moduledoc """
-    Testing do end block nesting.
-    """
-
-    def check(x) do
-        if x > 0 do
-            :ok
-        else
-            :error
-        end
-    end
-
-    def nested(x) do
-        if x > 0 do
-            if x > 10 do
-                :big
-            else
-                :small
-            end
-        else
-            :negative
-        end
-    end
-
-    def try_example(x) do
-        try do
-            x + 1
-        rescue
-            _ -> :error
-        end
-    end
+  defp accessLookup(map, x) do
+    map[map[map[map[x]]]]
+  end
 end
 
 # Keyword list syntactic sugar
-IO.puts inspect([a: 1, b: [c: 3, d: [e: 5, f: []]]])
+IO.puts(inspect(a: 1, b: [c: 3, d: [e: 5, f: []]]))
 
 # Map syntactic sugar
-IO.puts inspect(%{a => 1, b => %{c => 3, d => %{e => 5, f => %{}}}})
+IO.puts(inspect(%{a => 1, b => %{c => 3, d => %{e => 5, f => %{}}}}))
+
+defmodule AllBlocks do
+  def with_example(opts) do
+    with {:ok, a} <- Keyword.fetch(opts, :a),
+         {:ok, b} <- Keyword.fetch(opts, :b) do
+      a + b
+    else
+      :error -> :missing
+    end
+  end
+
+  def nested_with(opts) do
+    with {:ok, a} <- Keyword.fetch(opts, :a),
+         {:ok, b} <- Keyword.fetch(opts, :b) do
+      with {:ok, c} <- Keyword.fetch(opts, :c),
+           {:ok, d} <- Keyword.fetch(opts, :d) do
+        a + b + c + d
+      else
+        :error -> :inner_missing
+      end
+    else
+      :error -> :outer_missing
+    end
+  end
+
+  def fn_example do
+    add = fn x, y ->
+      x + y
+    end
+
+    nested = fn x ->
+      fn y ->
+        x + y
+      end
+    end
+
+    add.(1, nested.(2).(3))
+  end
+
+  def unless_example(x) do
+    unless x == 0 do
+      :nonzero
+    else
+      :zero
+    end
+  end
+
+  def case_example(x) do
+    case x do
+      :a -> 1
+      :b -> 2
+      _ -> 3
+    end
+  end
+
+  def nested_case(x, y) do
+    case x do
+      :a ->
+        case y do
+          :c -> 1
+          _ -> 2
+        end
+
+      _ ->
+        3
+    end
+  end
+
+  def cond_example(x) do
+    cond do
+      x > 10 -> :big
+      x > 0 -> :small
+      true -> :nonpositive
+    end
+  end
+
+  def for_example do
+    for x <- [1, 2, 3] do
+      x * 2
+    end
+
+    for x <- [1, 2, 3],
+        y <- [:a, :b] do
+      {x, y}
+    end
+  end
+
+  def receive_example do
+    receive do
+      {:msg, value} -> value
+      :stop -> :done
+    after
+      5000 -> :timeout
+    end
+  end
+
+  def nested_receive do
+    receive do
+      {:outer, pid} ->
+        receive do
+          {:inner, value} -> send(pid, value)
+        after
+          1000 -> :inner_timeout
+        end
+    after
+      5000 -> :outer_timeout
+    end
+  end
+
+  def if_example(x) do
+    if x > 0 do
+      :ok
+    else
+      :error
+    end
+  end
+
+  def nested_if(x) do
+    if x > 0 do
+      if x > 10 do
+        :big
+      else
+        :small
+      end
+    else
+      :negative
+    end
+  end
+
+  defmacro my_macro(expr) do
+    quote do
+      unquote(expr) + 1
+    end
+  end
+
+  def try_full(x) do
+    try do
+      if x > 0 do
+        :ok
+      else
+        raise "error"
+      end
+    rescue
+      e in RuntimeError -> {:error, e}
+    catch
+      :exit, reason -> {:exit, reason}
+    after
+      IO.puts("done")
+    end
+  end
+end

--- a/test/highlight/samples/heex/regular.heex
+++ b/test/highlight/samples/heex/regular.heex
@@ -1,0 +1,56 @@
+<div>
+  <span>Hello</span>
+  <p>
+    <a href="/">
+      <span>Link</span>
+    </a>
+  </p>
+</div>
+
+<br />
+<img src="logo.png" />
+
+<MyApp.Component>
+  <AnotherComponent>
+    <span>Nested</span>
+  </AnotherComponent>
+</MyApp.Component>
+
+<Widget />
+
+<MyApp.Component>
+  <:header>
+    <h1>Title</h1>
+  </:header>
+  <:body>
+    <p>
+      <span>Content</span>
+    </p>
+  </:body>
+</MyApp.Component>
+
+<%= if @show do %>
+  <div>
+    <%= for item <- @items do %>
+      <span><%= item.name %></span>
+    <% end %>
+  </div>
+<% end %>
+
+<%= if @logged_in do %>
+  <span>Welcome</span>
+<% else %>
+  <a href="/login">Log in</a>
+<% end %>
+
+<div>
+  <%= case @status do %>
+    <% :ok -> %>
+      <span>Success</span>
+    <% :error -> %>
+      <p>
+        <span>Error</span>
+      </p>
+  <% end %>
+</div>
+


### PR DESCRIPTION
This covers all elixir blocks and heex tags.

However, right now there is a problem with heex when adding any block support to Elixir itself. Specifically, when there is a "cond/case" in <%= %> <% %> tags. They are fundamentally broken at injection because after cleaning up tags we remain with -> with nothing after them which is invalid code that makes Elixir parser to recover and emit wrong ranges.

Visually, it breaks color for all further Elixir code in these tags:
<img width="341" height="387" alt="image" src="https://github.com/user-attachments/assets/28e81708-126f-47da-a245-41346e05cc94" />

Though I should mention colors are somewhat broken even without rainbow-delimiters:
<img width="330" height="388" alt="image" src="https://github.com/user-attachments/assets/af6ce244-e225-463a-882a-8bf7102f4751" />

I haven't added color to <%= %> <% %> tags because they are pretty rare and this way they would have their own basic color that makes them more visible, just a personal preference.