### PR TITLE
Update queries for OCaml

### DIFF
--- a/queries/ocaml/rainbow-blocks.scm
+++ b/queries/ocaml/rainbow-blocks.scm
@@ -12,12 +12,14 @@
     ((let_and_operator) @delimiter _)*)
   "in" @delimiter) @container
 
-(let_open_expression ; Line 268
+(let_expression ; Line 268
   "let" @delimiter
+  (open_module)
   "in" @delimiter) @container
 
-(let_module_expression ; Line 284
+(let_expression ; Line 284
   "let" @delimiter
+  (module_definition)
   "in" @delimiter) @container
 
 (match_expression ; Line 182
@@ -57,10 +59,6 @@
 ;;; Copied over from rainbow-delimiters
 
 (array_get_expression ; Line 8
-  "(" @delimiter
-  ")" @delimiter) @container
-
-(coercion_expression ; Line 122
   "(" @delimiter
   ")" @delimiter) @container
 

--- a/queries/ocaml/rainbow-delimiters.scm
+++ b/queries/ocaml/rainbow-delimiters.scm
@@ -2,10 +2,6 @@
   "(" @delimiter
   ")" @delimiter) @container
 
-(coercion_expression ; Line 122
-  "(" @delimiter
-  ")" @delimiter) @container
-
 (constructed_type ; Line 14
   "(" @delimiter
   ")" @delimiter) @container

--- a/test/highlight/samples/ocaml/regular.ml
+++ b/test/highlight/samples/ocaml/regular.ml
@@ -118,7 +118,7 @@ let square w =
 
 let squares : square list = [ square 10; square 20 ]
 
-(* coercion_expression *)
+(* now just a typed_expression node *)
 let shapes : shape list = (squares :> shape list)
 
 type x = { s : int list }
@@ -268,7 +268,7 @@ let () =
   z
 ;;
 
-(* let_open_expression *)
+(* let_expression with open_module *)
 let () =
   let open Option in
   ()


### PR DESCRIPTION
Update OCaml queries to match recent upstream grammar changes:
  - `let_open_expression` and `let_module_expression` are now part of `let_expression` node
  - `coercion_expression` is now part of `typed_expression` node which already has a separate query.

Relevant tree-sitter-ocaml commits:
https://github.com/tree-sitter/tree-sitter-ocaml/commit/28a93319a67a93780bbd484e6ed5b12dcbe7eddb
https://github.com/tree-sitter/tree-sitter-ocaml/commit/0633bf4be8037ab49743b25e2ab90974c1668aec

Note: As far as I know in OCaml 5.5 many other kinds of `let ... in` expressions will be allowed which will probably need new queries. I'm not yet familiar with the syntax for these since OCaml 5.5 is only in alpha testing as of now so I didn't write the queries for these (even though the tree-sitter grammar seems to have added support for them).
