### PR TITLE
Add visible strategy with async streaming delimiter highlighting

### DIFF
--- a/lua/rainbow-delimiters/strategy/visible/future_spawn.lua
+++ b/lua/rainbow-delimiters/strategy/visible/future_spawn.lua
@@ -1,0 +1,90 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Cooperative, incremental highlighting.  Highlighting a whole buffer -- or even
+-- just a large visible region -- can involve thousands of extmarks; doing it all
+-- in one go blocks the editor.  Instead a highlighting pass is expressed as a
+-- `poll` function which performs one small unit of work per call and returns
+-- whether any work remains.  Futures are drained one time slice at a time on a
+-- libuv timer, yielding back to the editor in between.
+--
+-- Futures are processed newest-first (the pending futures form a stack).  When
+-- the user scrolls or edits, the freshest request -- the region they are looking
+-- at right now -- preempts older, now less relevant work, so highlighting feels
+-- real-time.  Preemption happens at slice boundaries: a future interrupted this
+-- way keeps the progress of its `poll` and resumes once the newer futures are
+-- done.
+
+local uv = vim.uv or vim.loop
+
+---Nanoseconds of work to perform before yielding back to the event loop.
+local BUDGET_NS = 1000000 -- 1 ms
+
+---How often (in `poll` calls) to consult the clock.  Reading the clock on every
+---call would dominate the tiny per-call work, so we only check periodically.
+local CHECK_EVERY = 100
+
+---@class rainbow_delimiters.future.Future
+---@field poll fun(): boolean One unit of work; returns whether more remains
+---@field is_stale fun(): boolean The future is dropped if this returns true
+---@field on_stale? fun() Function to run if the future is stale.
+
+---Pending futures, processed from the top (most recently submitted) down.
+---@type rainbow_delimiters.future.Future[]
+local futures = {}
+local timer = assert(uv.new_timer())
+local pending = false
+
+---Process pending futures, newest first, until the time budget for this slice is
+---used up, then reschedule for the next event loop iteration.  A slice runs to
+---completion without yielding, so the stack only ever changes between slices --
+---which is what lets a future submitted in the meantime be served first.
+local function schedule()
+	local deadline = uv.hrtime() + BUDGET_NS
+	local n = 0
+
+	while #futures > 0 do
+		n = n + 1
+
+		-- Always take the most recent submission.
+		local fut = futures[#futures]
+
+		if fut.is_stale() then
+			futures[#futures] = nil
+			if fut.on_stale ~= nil then
+				fut.on_stale()
+			end
+		else
+			while true do
+				n = n + 1
+
+				if not fut.poll() then
+					futures[#futures] = nil
+					break
+				end
+
+				if n % CHECK_EVERY == 0 and uv.hrtime() > deadline then
+					timer:start(0, 0, vim.schedule_wrap(schedule))
+					return
+				end
+			end
+		end
+
+		if n % CHECK_EVERY == 0 and uv.hrtime() > deadline then
+			timer:start(0, 0, vim.schedule_wrap(schedule))
+			return
+		end
+	end
+
+	pending = false
+end
+
+---Submit a future.  It becomes the new top of the stack and is picked up on the
+---next event loop iteration, ahead of any older pending work.
+---@param fut rainbow_delimiters.future.Future
+return function(fut)
+	futures[#futures + 1] = fut
+	if not pending then
+		pending = true
+		schedule()
+	end
+end

--- a/lua/rainbow-delimiters/strategy/visible/hl-epoch.lua
+++ b/lua/rainbow-delimiters/strategy/visible/hl-epoch.lua
@@ -1,0 +1,31 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+---Per-buffer highlighting epochs.
+local M = {}
+
+---@type table<integer, integer>
+local epochs = {}
+
+---Return the current epoch.
+---@param bufnr integer
+---@return integer epoch
+function M.current(bufnr)
+	return epochs[bufnr] or 0
+end
+
+---Advance the epoch.
+---@param bufnr integer
+---@return integer epoch
+function M.bump(bufnr)
+	local epoch = M.current(bufnr) + 1
+	epochs[bufnr] = epoch
+	return epoch
+end
+
+---Clear the epoch.
+---@param bufnr integer
+function M.clear(bufnr)
+	epochs[bufnr] = nil
+end
+
+return M

--- a/lua/rainbow-delimiters/strategy/visible/hl-node.lua
+++ b/lua/rainbow-delimiters/strategy/visible/hl-node.lua
@@ -1,0 +1,131 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Streaming match iteration and highlighting.  This library is only relevant
+-- to strategy authors.  It walks the buffer's syntax tree in nesting order,
+-- yielding each query match together with its highlight level, and applies the
+-- delimiter highlighting one match at a time.
+
+local nvim_buf_set_extmark = vim.api.nvim_buf_set_extmark
+
+local lib = require 'rainbow-delimiters.lib'
+local Set = require 'rainbow-delimiters.set'
+
+--- Streaming, pre-order DFS version of Query:iter_matches().
+---
+--- Yields each match when its pattern's *root* node is reached in a
+--- pre-order walk, so enclosing/earlier matches come first. State is
+--- only the DFS stack (O(tree depth)); nothing is buffered up front.
+---
+--- Trade-off: runs one (root-only) query cursor per visited node, so
+--- it does more total work than the single-pass built-in.
+---
+---@param query vim.treesitter.Query
+---@param node vim.treesitter.TSNode
+---@param bufnr integer
+---@param start_row integer First row to highlight, inclusive
+---@param end_row integer Last row to highlight, exclusive
+---@return fun(): (integer, table<integer, TSNode[]>) next_match
+local function iter_matches(query, node, bufnr, start_row, end_row)
+	return coroutine.wrap(function()
+		local queue = { { node, 1 } }
+
+		while #queue > 0 do
+			local tail = queue[#queue]
+			queue[#queue] = nil
+
+			local n = tail[1]
+			local level = tail[2]
+
+			-- `max_start_depth = 0` => only patterns whose root is exactly `n`.
+			-- Predicates/directives are already applied by iter_matches.
+			local matches = query:iter_matches(n, bufnr, start_row, end_row, { max_start_depth = 0 })
+
+			local _, first_match = matches()
+			local next_level = level
+			if first_match ~= nil then
+				-- only increase level if we are in container to
+				-- avoid yielding the AST level.
+				next_level = next_level + 1
+				coroutine.yield(level, first_match)
+			end
+
+			for _, match in matches do
+				coroutine.yield(level, match)
+			end
+
+			for child in n:iter_children() do
+				if child:end_() >= start_row and child:start() < end_row then
+					queue[#queue + 1] = { child, next_level }
+				end
+			end
+		end
+	end)
+end
+
+---Create a polling function which highlights the delimiters of all matches
+---reachable from `root_node` within `[start_row, end_row)`.  Each call to the
+---returned function processes a single match and reports whether there is more
+---work left to do, allowing the caller to spread the work across multiple event
+---loop iterations.
+---
+---@param query vim.treesitter.Query
+---@param root_node vim.treesitter.TSNode
+---@param bufnr integer
+---@param start_row integer First row to highlight, inclusive
+---@param end_row integer Last row to highlight, exclusive
+---@param nsid integer Namespace for the extmarks
+---@param priority integer Priority of the extmarks
+---@return fun(): boolean poll
+return function(query, root_node, bufnr, start_row, end_row, nsid, priority)
+	local next_match = iter_matches(query, root_node, bufnr, start_row, end_row)
+	local prev_level = 1
+	local hlgroup = lib.hlgroup_at(1)
+
+	local function poll()
+		local level, match = next_match()
+		if level == nil then
+			return false
+		end
+
+		local delimiters = Set.new()
+		for id, nodes in pairs(match) do
+			if query.captures[id] == 'delimiter' then
+				-- It is expected for a match to contain any number of delimiters
+				for _, node in ipairs(nodes) do
+					local s_row, _, e_row, _ = node:range()
+					if e_row >= start_row and s_row < end_row then
+						-- Only delimiters which intersect the view range need to be highlighted.
+						delimiters:add(node)
+					end
+				end
+			else
+				-- This can only be container.
+				-- We assume that there is only ever exactly one node per container capture.
+				local s_row, _, e_row, _ = nodes[1]:range()
+				if e_row < start_row or s_row >= end_row then
+					-- Node range does not overlap with the view range
+					return true
+				end
+			end
+		end
+
+		if level ~= prev_level then
+			hlgroup = lib.hlgroup_at(level)
+			prev_level = level
+		end
+
+		for delimiter in delimiters:items() do
+			local s_row, s_col, e_row, e_col = delimiter:range()
+			nvim_buf_set_extmark(bufnr, nsid, s_row, s_col, {
+				end_row = e_row,
+				end_col = e_col,
+				priority = priority,
+				hl_group = hlgroup,
+				strict = false
+			})
+		end
+
+		return true
+	end
+	return poll
+end

--- a/lua/rainbow-delimiters/strategy/visible/hl-range.lua
+++ b/lua/rainbow-delimiters/strategy/visible/hl-range.lua
@@ -1,0 +1,133 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+---Highlighted range cache.
+local M = {}
+
+-- For every attached buffer we remember which rows have already been
+-- highlighted.  The value is a list of `{start, stop}` pairs (zero-based,
+-- end-exclusive) which is kept sorted in ascending order and free of
+-- overlapping or touching ranges.
+---@type table<integer, integer[][]>
+local highlighted = {}
+
+---Return the sub-ranges of `[top, bot)` which are *not* yet highlighted.
+---@param bufnr integer
+---@param from integer First row, inclusive
+---@param to integer Last row, exclusive
+---@return integer[][] gaps  List of `{start, stop}` ranges, end-exclusive
+function M.gaps(bufnr, from, to)
+	local gaps = {}
+	if from >= to then return gaps end
+
+	local cursor = from
+	for _, range in ipairs(highlighted[bufnr] or {}) do
+		if range[1] >= to then
+			break
+		elseif range[2] > cursor then
+			if range[1] > cursor then
+				gaps[#gaps + 1] = { cursor, range[1] }
+			end
+			cursor = range[2]
+			if cursor >= to then return gaps end
+		end
+	end
+	if cursor < to then
+		gaps[#gaps + 1] = { cursor, to }
+	end
+	return gaps
+end
+
+---Mark `[top, bot)` as highlighted, merging it into the cached ranges.
+---@param bufnr integer
+---@param from integer First row, inclusive
+---@param to integer Last row, exclusive
+function M.insert(bufnr, from, to)
+	if from >= to then return end
+
+	local merged = {}
+	local lo, hi = from, to
+	local placed = false
+	for _, range in ipairs(highlighted[bufnr] or {}) do
+		if range[2] < lo then
+			merged[#merged + 1] = range
+		elseif range[1] > hi then
+			if not placed then
+				merged[#merged + 1] = { lo, hi }
+				placed = true
+			end
+			merged[#merged + 1] = range
+		else
+			lo = math.min(lo, range[1])
+			hi = math.max(hi, range[2])
+		end
+	end
+	if not placed then
+		merged[#merged + 1] = { lo, hi }
+	end
+	highlighted[bufnr] = merged
+end
+
+---Drop the rows in `[from, to)` from the cache so they will be highlighted
+---again.  Ranges which are only partially covered are split.
+---@param bufnr integer
+---@param from integer First row to drop, inclusive
+---@param to integer Last row to drop, exclusive (may be `math.huge`)
+function M.remove(bufnr, from, to)
+	if from >= to then return end
+
+	local ranges = highlighted[bufnr]
+	if ranges == nil then return end
+
+	local kept = {}
+	for _, range in ipairs(ranges) do
+		if range[2] <= from or range[1] >= to then
+			kept[#kept + 1] = range
+		else
+			if range[1] < from then
+				kept[#kept + 1] = { range[1], from }
+			end
+			if range[2] > to then
+				kept[#kept + 1] = { to, range[2] }
+			end
+		end
+	end
+	highlighted[bufnr] = kept
+end
+
+---Clear the highlight cache in buffer
+---@param bufnr integer
+function M.clear(bufnr)
+	highlighted[bufnr] = nil
+end
+
+---Update highlight ranges after text insertion or deletion.
+---@param bufnr integer
+---@param from integer Start row of the changed text
+---@param delta integer Number of lines changed
+function M.changed(bufnr, from, offset_old, offset_new)
+	if offset_old == offset_new then return end
+
+	local ranges = highlighted[bufnr]
+	if ranges == nil then return end
+
+	local kept = {}
+	local delta = offset_new - offset_old
+	local to = from + offset_old
+	for _, range in ipairs(ranges) do
+		if range[2] <= from then
+			kept[#kept + 1] = range
+		elseif range[1] >= to then
+			kept[#kept + 1] = { range[1] + delta, range[2] + delta }
+		else
+			if range[1] < from then
+				kept[#kept + 1] = { range[1], from }
+			end
+			if range[2] > to then
+				kept[#kept + 1] = { from + offset_new, range[2] + delta }
+			end
+		end
+	end
+	highlighted[bufnr] = kept
+end
+
+return M

--- a/lua/rainbow-delimiters/strategy/visible/init.lua
+++ b/lua/rainbow-delimiters/strategy/visible/init.lua
@@ -1,0 +1,209 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+-- The visible strategy highlights only the delimiters which are currently
+-- visible in the window and refreshes them whenever the cursor moves or the
+-- window scrolls.  Re-highlighting every visible line on each of those events
+-- is wasteful, so we keep a per-buffer cache of the row ranges which have
+-- already been highlighted.  When the visible region changes only the rows
+-- which are not yet cached are highlighted; moving the cursor around within
+-- lines that have already been rendered therefore does no work at all.
+--
+-- A text change invalidates the cache from the first changed row downwards --
+-- rows above an edit never move, so their highlighting stays valid -- and the
+-- affected rows are highlighted again on the next update.
+
+local api = vim.api
+
+local config = require 'rainbow-delimiters.config'
+local future_spawn = require 'rainbow-delimiters.strategy.visible.future_spawn'
+local hl_epoch = require 'rainbow-delimiters.strategy.visible.hl-epoch'
+local hl_node = require 'rainbow-delimiters.strategy.visible.hl-node'
+local hl_range = require 'rainbow-delimiters.strategy.visible.hl-range'
+local lib = require 'rainbow-delimiters.lib'
+local log = require 'rainbow-delimiters.log'
+local util = require 'rainbow-delimiters.util'
+
+---Highlight visible rows.
+---@param bufnr integer
+---@param parser vim.treesitter.LanguageTree
+local function hl_visible(bufnr, epoch, parser)
+	if vim.fn.pumvisible() ~= 0 then return end
+
+	local winnr = api.nvim_get_current_win()
+	local top = vim.fn.line('w0', winnr) - 1
+	local bot = vim.fn.line('w$', winnr)
+
+	if #hl_range.gaps(bufnr, top, bot) == 0 then return end
+
+	local function is_stale()
+		return
+			not api.nvim_buf_is_loaded(bufnr) or
+			not lib.buffers[bufnr] or
+			hl_epoch.current(bufnr) ~= epoch
+	end
+
+	parser:parse({ top, bot }, function(err)
+		if is_stale() or err ~= nil then return end
+
+		for _, gap in ipairs(hl_range.gaps(bufnr, top, bot)) do
+			local g_top, g_bot = gap[1], gap[2]
+
+			-- Cache up front so concurrent updates do not queue the same work twice.
+			local removed = false
+			hl_range.insert(bufnr, g_top, g_bot)
+
+			parser:for_each_tree(function(tree, sub_parser)
+				local lang = sub_parser:lang()
+				if not lib.enabled_for(lang) then return end
+
+				local query = lib.get_query(lang, bufnr)
+				if not query then return end
+
+				local nsid = lib.nsids[lang]
+				local priority = config.priority[lang]
+				if type(priority) == "function" then
+					priority = priority(bufnr)
+				end
+
+				local root = tree:root()
+				future_spawn {
+					poll = hl_node(query, root, bufnr, g_top, g_bot, nsid, priority),
+					is_stale = is_stale,
+					on_stale = function()
+						if not removed then
+							hl_range.remove(bufnr, g_top, g_bot)
+							removed = true
+							if
+								api.nvim_buf_is_loaded(bufnr) and
+								lib.buffers[bufnr] and
+								lib.buffers[bufnr].parser == parser
+							then
+								hl_visible(bufnr, hl_epoch.current(bufnr), parser)
+							end
+						end
+					end
+				}
+			end)
+		end
+	end)
+end
+
+---Register the change callbacks for the parser and all of its children.  This
+---does not highlight anything; the caller triggers highlighting separately so
+---that the function is safe to call from within an `on_child_added` callback.
+---@param bufnr integer
+---@param parser vim.treesitter.LanguageTree
+---@param start_parent_lang string?
+local function setup_parser(bufnr, parser, start_parent_lang)
+	log.debug('Setting up parser for buffer %d', bufnr)
+
+	---Sets up an individual parser for a particular language
+	---@param lang_parser vim.treesitter.LanguageTree
+	---@param lang string
+	local function f(lang_parser, lang)
+		log.debug("Setting up parser for '%s' in buffer %d", lang, bufnr)
+
+		-- Skip languages which are not supported, otherwise we get a
+		-- nil-reference error
+		if not lib.get_query(lang, bufnr) then return end
+
+		local nsid = lib.nsids[lang]
+		local pendings = {}
+
+		lang_parser:register_cbs {
+			on_bytes = function(_, _, from, _, _, offset_old, _, _, offset_new)
+				pendings[#pendings + 1] = { from, offset_old, offset_new }
+			end,
+			on_changedtree = function(ranges)
+				local need_hl = false
+				if #ranges == 0 and #pendings > 0 then
+					-- Changes does not affect tree levels,
+					-- but highlighted ranges needs to be updated.
+					for _, pending in ipairs(pendings) do
+						need_hl = need_hl or pending[2] ~= pending[3]
+						hl_range.changed(bufnr, pending[1], pending[2], pending[3])
+					end
+				else
+					need_hl = #ranges > 0
+					for _, range in ipairs(ranges) do
+						local from = range[1]
+						local to = range[3]
+						if #range == 6 then
+							to = range[4]
+						end
+						hl_range.remove(bufnr, from, to)
+						vim.api.nvim_buf_clear_namespace(bufnr, nsid, from, to)
+					end
+				end
+				pendings = {}
+
+				if need_hl then
+					hl_visible(bufnr, hl_epoch.bump(bufnr), lib.buffers[bufnr].parser)
+				end
+			end,
+			on_child_added = function(child)
+				setup_parser(bufnr, child, lang)
+			end,
+		}
+
+		log.trace("Done with setting up parser for '%s' in buffer %d", lang, bufnr)
+	end
+
+	-- A buffer has one primary language and potentially many child languages
+	-- which may have child languages of their own.  We need to set up the
+	-- parser for each of them.  Highlighting is left to the caller so that this
+	-- function is safe to call from within an `on_child_added` callback.
+	util.for_each_child(start_parent_lang, parser:lang(), parser, f)
+end
+
+---Reusable autogroup for events in this strategy.
+---@type integer
+local augroup = api.nvim_create_augroup('TSRainbowVisibleStrategy', {})
+
+---@param bufnr integer
+---@param settings rainbow_delimiters.buffer_settings
+local function on_attach(bufnr, settings)
+	log.trace('visible strategy on_attach for buffer %d', bufnr)
+
+	local parser = settings.parser
+	setup_parser(bufnr, parser, nil)
+	hl_visible(bufnr, hl_epoch.bump(bufnr), parser)
+
+	api.nvim_create_autocmd('WinScrolled', {
+		group = augroup,
+		buffer = bufnr,
+		callback = function()
+			hl_visible(bufnr, hl_epoch.current(bufnr), parser)
+		end
+	})
+end
+
+---@param bufnr integer
+local function on_detach(bufnr)
+	log.trace('visible strategy on_detach for buffer %d', bufnr)
+
+	hl_range.clear(bufnr)
+	hl_epoch.clear(bufnr)
+	api.nvim_clear_autocmds { buffer = bufnr, group = augroup }
+end
+
+---@param bufnr integer
+---@param settings rainbow_delimiters.buffer_settings
+local function on_reset(bufnr, settings)
+	log.trace('visible strategy on_reset for buffer %d', bufnr)
+
+	hl_range.clear(bufnr)
+	local parser = settings.parser
+	util.for_each_child(nil, parser:lang(), parser, function(_, lang)
+		lib.clear_namespace(bufnr, lang)
+	end)
+	hl_visible(bufnr, hl_epoch.bump(bufnr), parser)
+end
+
+---Strategy which highlights the delimiters visible in the current window.
+---@type rainbow_delimiters.strategy
+return {
+	on_attach = on_attach,
+	on_detach = on_detach,
+	on_reset = on_reset,
+}


### PR DESCRIPTION
Introduces a new strategy that highlights only the delimiters currently visible in the window.

Rather than highlighting the entire visible region in one blocking pass, the strategy uses future-based async scheduling and streaming match iteration to keep the editor responsive:
- Async futures (future_spawn.lua) — Each highlighting pass is split into small units of work drained in 1ms time slices on a libuv timer, yielding back to the event loop between slices. Futures are processed newest-first (LIFO), so scrolling or editing immediately preempts stale work in favor of the region the user is looking at right now.
- Streaming iteration (hl-node.lua) — A coroutine-driven pre-order DFS walks the syntax tree and yields one match at a time, without buffering anything up front. Each poll call processes a single match, allowing the async scheduler to interleave highlighting with editor input.

A per-buffer cache of highlighted row ranges avoids redundant work on `WinScrolled` (only newly revealed lines are processed). On text change, the cache is invalidated from the first changed row downwards.

Tested on a 10M deeply nested JSON file: the global strategy freezes editor for ~40s, while the visible strategy makes highlighting available immediately — even during fast scrolling.